### PR TITLE
Add unit tests for core utilities

### DIFF
--- a/blog-generic/src/author_slug_utils.rs
+++ b/blog-generic/src/author_slug_utils.rs
@@ -9,3 +9,45 @@ pub fn clean(slug: &String) -> String {
 pub fn extend(slug: &String, suffix: &String) -> String {
     format!("{slug}{SPLIT_SYMBOL}{suffix}")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_removes_suffix() {
+        let slug = String::from("author^extra");
+        assert_eq!(clean(&slug), "author");
+    }
+
+    #[test]
+    fn clean_returns_original_when_no_symbol() {
+        let slug = String::from("author");
+        assert_eq!(clean(&slug), "author");
+    }
+
+    #[test]
+    fn clean_handles_multiple_symbols() {
+        let slug = String::from("author^mid^end");
+        assert_eq!(clean(&slug), "author^mid");
+    }
+
+    #[test]
+    fn clean_handles_empty_string() {
+        let slug = String::new();
+        assert_eq!(clean(&slug), "");
+    }
+
+    #[test]
+    fn extend_joins_slug_and_suffix() {
+        let slug = String::from("author");
+        let suffix = String::from("meta");
+        assert_eq!(extend(&slug, &suffix), "author^meta");
+    }
+
+    #[test]
+    fn extend_allows_empty_parts() {
+        assert_eq!(extend(&String::new(), &String::from("meta")), "^meta");
+        assert_eq!(extend(&String::from("author"), &String::new()), "author^");
+    }
+}

--- a/blog-generic/src/page_processor.rs
+++ b/blog-generic/src/page_processor.rs
@@ -23,3 +23,40 @@ impl<const LIMIT: u64> PageProcessor for DefaultPageProcessor<LIMIT> {
         offset
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_one_has_zero_offset() {
+        let processor = DefaultPageProcessor::<10>::create_for_page(&1);
+        assert_eq!(processor.limit(), 10);
+        assert_eq!(processor.offset(), 0);
+    }
+
+    #[test]
+    fn page_zero_does_not_underflow() {
+        let processor = DefaultPageProcessor::<10>::create_for_page(&0);
+        assert_eq!(processor.offset(), 0);
+    }
+
+    #[test]
+    fn page_five_calculates_correct_offset() {
+        let processor = DefaultPageProcessor::<10>::create_for_page(&5);
+        assert_eq!(processor.offset(), 40);
+    }
+
+    #[test]
+    fn custom_limit_is_respected() {
+        let processor = DefaultPageProcessor::<20>::create_for_page(&2);
+        assert_eq!(processor.limit(), 20);
+        assert_eq!(processor.offset(), 20);
+    }
+
+    #[test]
+    fn high_page_with_limit_one_avoids_overflow() {
+        let processor = DefaultPageProcessor::<1>::create_for_page(&u64::MAX);
+        assert_eq!(processor.offset(), u64::MAX - 1);
+    }
+}

--- a/blog-server-api/src/endpoints/author/handler.rs
+++ b/blog-server-api/src/endpoints/author/handler.rs
@@ -41,3 +41,176 @@ pub async fn direct_handler(
     .ok()
     .map(|s| s.container)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use blog_server_services::traits::author_service::{
+        Author, BaseAuthor, BaseMinimalAuthor, BaseSecondaryAuthor,
+    };
+    use screw_components::dyn_result::DResult;
+
+    enum MockBehavior {
+        Success(Option<Author>),
+        Error,
+    }
+
+    struct MockAuthorService {
+        behavior: MockBehavior,
+    }
+
+    #[async_trait]
+    impl AuthorService for MockAuthorService {
+        async fn authors_count_by_query(&self, _query: &String) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn authors_by_query(
+            &self,
+            _query: &String,
+            _offset: &u64,
+            _limit: &u64,
+        ) -> DResult<Vec<Author>> {
+            unimplemented!()
+        }
+
+        async fn authors_count(&self) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn authors(&self, _offset: &u64, _limit: &u64) -> DResult<Vec<Author>> {
+            unimplemented!()
+        }
+
+        async fn authors_by_ids(&self, _ids: &std::collections::HashSet<u64>) -> DResult<Vec<Author>> {
+            unimplemented!()
+        }
+
+        async fn author_by_id(&self, _id: &u64) -> DResult<Option<Author>> {
+            unimplemented!()
+        }
+
+        async fn author_by_slug(&self, _slug: &String) -> DResult<Option<Author>> {
+            match &self.behavior {
+                MockBehavior::Success(author) => Ok(author.clone()),
+                MockBehavior::Error => Err("db error".into()),
+            }
+        }
+
+        async fn author_by_yandex_id(&self, _yandex_id: &u64) -> DResult<Option<Author>> {
+            unimplemented!()
+        }
+
+        async fn author_by_telegram_id(&self, _telegram_id: &u64) -> DResult<Option<Author>> {
+            unimplemented!()
+        }
+
+        async fn set_author_override_social_data_by_id(
+            &self,
+            _id: &u64,
+            _override_social_data: &u8,
+        ) -> DResult<()> {
+            unimplemented!()
+        }
+
+        async fn update_minimal_custom_author_by_id(
+            &self,
+            _id: &u64,
+            _base_minimal_author: &BaseMinimalAuthor,
+        ) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn update_minimal_social_author_by_id(
+            &self,
+            _id: &u64,
+            _base_minimal_author: &BaseMinimalAuthor,
+            _yandex_id: Option<&u64>,
+            _telegram_id: Option<&u64>,
+        ) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn insert_minimal_social_author(
+            &self,
+            _base_minimal_author: &BaseMinimalAuthor,
+            _yandex_id: Option<&u64>,
+            _telegram_id: Option<&u64>,
+        ) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn update_secondary_author_by_id(
+            &self,
+            _id: &u64,
+            _base_secondary_author: &BaseSecondaryAuthor,
+        ) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn set_author_blocked_by_id(&self, _id: &u64, _is_blocked: &u8) -> DResult<()> {
+            unimplemented!()
+        }
+
+        async fn set_author_subscription_by_id(
+            &self,
+            _id: &u64,
+            _is_subscribed: &u8,
+        ) -> DResult<()> {
+            unimplemented!()
+        }
+    }
+
+    fn sample_author() -> Author {
+        Author {
+            id: 1,
+            base: BaseAuthor {
+                slug: "john".into(),
+                first_name: Some("John".into()),
+                middle_name: None,
+                last_name: Some("Doe".into()),
+                mobile: None,
+                email: None,
+                password_hash: None,
+                registered_at: 0,
+                status: None,
+                image_url: None,
+                editor: 0,
+                blocked: 0,
+                yandex_id: None,
+                telegram_id: None,
+                notification_subscribed: None,
+                override_social_data: 0,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_slug_returns_error() {
+        let service = Arc::new(MockAuthorService { behavior: MockBehavior::Success(None) });
+        let result = http_handler((AuthorRequestContent { slug: String::new(), author_service: service },)).await;
+        assert!(matches!(result, Err(SlugEmpty)));
+    }
+
+    #[tokio::test]
+    async fn not_found_returns_error() {
+        let service = Arc::new(MockAuthorService { behavior: MockBehavior::Success(None) });
+        let result = http_handler((AuthorRequestContent { slug: "missing".into(), author_service: service },)).await;
+        assert!(matches!(result, Err(NotFound)));
+    }
+
+    #[tokio::test]
+    async fn db_error_propagates() {
+        let service = Arc::new(MockAuthorService { behavior: MockBehavior::Error });
+        let result = http_handler((AuthorRequestContent { slug: "john".into(), author_service: service },)).await;
+        assert!(matches!(result, Err(DatabaseError { .. })));
+    }
+
+    #[tokio::test]
+    async fn success_returns_author() {
+        let service = Arc::new(MockAuthorService { behavior: MockBehavior::Success(Some(sample_author())) });
+        let result = http_handler((AuthorRequestContent { slug: "john".into(), author_service: service },)).await;
+        assert!(matches!(result, Ok(_)));
+    }
+}

--- a/blog-server-api/src/endpoints/login/handler.rs
+++ b/blog-server-api/src/endpoints/login/handler.rs
@@ -76,3 +76,221 @@ pub async fn http_handler(
 
     Ok(token.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use blog_server_services::traits::author_service::{
+        Author, BaseAuthor, BaseMinimalAuthor, BaseSecondaryAuthor, AuthorService,
+    };
+    use screw_components::dyn_result::DResult;
+    use std::sync::Arc;
+
+    enum MockBehavior {
+        Success(Option<Author>),
+        Error,
+    }
+
+    struct MockAuthorService {
+        behavior: MockBehavior,
+    }
+
+    #[async_trait]
+    impl AuthorService for MockAuthorService {
+        async fn authors_count_by_query(&self, _query: &String) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn authors_by_query(
+            &self,
+            _query: &String,
+            _offset: &u64,
+            _limit: &u64,
+        ) -> DResult<Vec<Author>> {
+            unimplemented!()
+        }
+
+        async fn authors_count(&self) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn authors(&self, _offset: &u64, _limit: &u64) -> DResult<Vec<Author>> {
+            unimplemented!()
+        }
+
+        async fn authors_by_ids(
+            &self,
+            _ids: &std::collections::HashSet<u64>,
+        ) -> DResult<Vec<Author>> {
+            unimplemented!()
+        }
+
+        async fn author_by_id(&self, _id: &u64) -> DResult<Option<Author>> {
+            unimplemented!()
+        }
+
+        async fn author_by_slug(&self, _slug: &String) -> DResult<Option<Author>> {
+            match &self.behavior {
+                MockBehavior::Success(author) => Ok(author.clone()),
+                MockBehavior::Error => Err("db error".into()),
+            }
+        }
+
+        async fn author_by_yandex_id(&self, _yandex_id: &u64) -> DResult<Option<Author>> {
+            unimplemented!()
+        }
+
+        async fn author_by_telegram_id(
+            &self,
+            _telegram_id: &u64,
+        ) -> DResult<Option<Author>> {
+            unimplemented!()
+        }
+
+        async fn set_author_override_social_data_by_id(
+            &self,
+            _id: &u64,
+            _override_social_data: &u8,
+        ) -> DResult<()> {
+            unimplemented!()
+        }
+
+        async fn update_minimal_custom_author_by_id(
+            &self,
+            _id: &u64,
+            _base_minimal_author: &BaseMinimalAuthor,
+        ) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn update_minimal_social_author_by_id(
+            &self,
+            _id: &u64,
+            _base_minimal_author: &BaseMinimalAuthor,
+            _yandex_id: Option<&u64>,
+            _telegram_id: Option<&u64>,
+        ) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn insert_minimal_social_author(
+            &self,
+            _base_minimal_author: &BaseMinimalAuthor,
+            _yandex_id: Option<&u64>,
+            _telegram_id: Option<&u64>,
+        ) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn update_secondary_author_by_id(
+            &self,
+            _id: &u64,
+            _base_secondary_author: &BaseSecondaryAuthor,
+        ) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn set_author_blocked_by_id(&self, _id: &u64, _is_blocked: &u8) -> DResult<()> {
+            unimplemented!()
+        }
+
+        async fn set_author_subscription_by_id(
+            &self,
+            _id: &u64,
+            _is_subscribed: &u8,
+        ) -> DResult<()> {
+            unimplemented!()
+        }
+    }
+
+    fn sample_author(password_hash: Option<String>) -> Author {
+        Author {
+            id: 1,
+            base: BaseAuthor {
+                slug: "john".into(),
+                first_name: None,
+                middle_name: None,
+                last_name: None,
+                mobile: None,
+                email: None,
+                password_hash,
+                registered_at: 0,
+                status: None,
+                image_url: None,
+                editor: 0,
+                blocked: 0,
+                yandex_id: None,
+                telegram_id: None,
+                notification_subscribed: None,
+                override_social_data: 0,
+            },
+        }
+    }
+
+    async fn reset_storage() {
+        LOGIN_TRY_STORAGE.lock().await.clear();
+    }
+
+    #[tokio::test]
+    async fn empty_slug_returns_error() {
+        reset_storage().await;
+        let service = Arc::new(MockAuthorService { behavior: MockBehavior::Success(None) });
+        let result = http_handler((LoginRequestContent {
+            login_question: Ok(LoginQuestion { slug: String::new(), password: String::new() }),
+            author_service: service,
+        },)).await;
+        assert!(matches!(result, Err(SlugEmpty)));
+    }
+
+    #[tokio::test]
+    async fn not_found_returns_error() {
+        reset_storage().await;
+        let service = Arc::new(MockAuthorService { behavior: MockBehavior::Success(None) });
+        let result = http_handler((LoginRequestContent {
+            login_question: Ok(LoginQuestion { slug: "missing".into(), password: "pwd".into() }),
+            author_service: service,
+        },)).await;
+        assert!(matches!(result, Err(NotFound)));
+    }
+
+    #[tokio::test]
+    async fn db_error_propagates() {
+        reset_storage().await;
+        let service = Arc::new(MockAuthorService { behavior: MockBehavior::Error });
+        let result = http_handler((LoginRequestContent {
+            login_question: Ok(LoginQuestion { slug: "john".into(), password: "pwd".into() }),
+            author_service: service,
+        },)).await;
+        assert!(matches!(result, Err(DatabaseError { .. })));
+    }
+
+    #[tokio::test]
+    async fn wrong_password_returns_error() {
+        reset_storage().await;
+        let hash = password::hash(&"secret".to_string()).unwrap();
+        let service = Arc::new(MockAuthorService {
+            behavior: MockBehavior::Success(Some(sample_author(Some(hash)))),
+        });
+        let result = http_handler((LoginRequestContent {
+            login_question: Ok(LoginQuestion { slug: "john".into(), password: "wrong".into() }),
+            author_service: service,
+        },)).await;
+        assert!(matches!(result, Err(WrongPassword)));
+    }
+
+    #[tokio::test]
+    async fn success_returns_token() {
+        reset_storage().await;
+        std::env::set_var("JWT_SECRET", "secret");
+        let hash = password::hash(&"secret".to_string()).unwrap();
+        let service = Arc::new(MockAuthorService {
+            behavior: MockBehavior::Success(Some(sample_author(Some(hash.clone())))),
+        });
+        let result = http_handler((LoginRequestContent {
+            login_question: Ok(LoginQuestion { slug: "john".into(), password: "secret".into() }),
+            author_service: service,
+        },)).await;
+        assert!(matches!(result, Ok(_)));
+    }
+}

--- a/blog-server-api/src/endpoints/posts/handler.rs
+++ b/blog-server-api/src/endpoints/posts/handler.rs
@@ -148,3 +148,185 @@ pub async fn direct_handler(
     .ok()
     .map(|s| s.container)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use blog_server_services::traits::{
+        author_service::{Author as SAuthor, AuthorService, BaseAuthor, BaseMinimalAuthor, BaseSecondaryAuthor},
+        entity_post_service::EntityPostService,
+        post_service::{PostService, Post},
+    };
+    use blog_generic::entities::Post as EPost;
+    use screw_components::dyn_result::DResult;
+
+    enum PostBehavior {
+        Success(u64),
+        Error,
+    }
+
+    struct MockPostService {
+        behavior: PostBehavior,
+    }
+
+    #[async_trait]
+    impl PostService for MockPostService {
+        async fn posts<'q, 'a, 't, 'p, 'o, 'l>(
+            &self,
+            _request: PostsQuery<'q, 'a, 't, 'p, 'o, 'l>,
+        ) -> DResult<PostsQueryAnswer> {
+            match self.behavior {
+                PostBehavior::Success(total) => Ok(PostsQueryAnswer { total_count: total, posts: vec![] }),
+                PostBehavior::Error => Err("db error".into()),
+            }
+        }
+
+        async fn post_by_id(&self, _id: &u64) -> DResult<Option<Post>> {
+            unimplemented!()
+        }
+
+        async fn create_post(&self, _post: &blog_server_services::traits::post_service::BasePost) -> DResult<u64> {
+            unimplemented!()
+        }
+
+        async fn update_post_by_id(
+            &self,
+            _id: &u64,
+            _post: &blog_server_services::traits::post_service::BasePost,
+            _update_created_at: &bool,
+        ) -> DResult<()> {
+            unimplemented!()
+        }
+
+        async fn delete_post_by_id(&self, _id: &u64) -> DResult<()> {
+            unimplemented!()
+        }
+
+        async fn tag_by_id(&self, _id: &u64) -> DResult<Option<blog_server_services::traits::post_service::Tag>> {
+            unimplemented!()
+        }
+
+        async fn create_tags(&self, _tag_titles: Vec<String>) -> DResult<Vec<blog_server_services::traits::post_service::Tag>> {
+            unimplemented!()
+        }
+
+        async fn merge_post_tags(&self, _post_id: &u64, _tags: Vec<blog_server_services::traits::post_service::Tag>) -> DResult<()> {
+            unimplemented!()
+        }
+    }
+
+    enum EntityBehavior {
+        Success(Vec<EPost>),
+        Error,
+    }
+
+    struct MockEntityPostService {
+        behavior: EntityBehavior,
+    }
+
+    #[async_trait]
+    impl EntityPostService for MockEntityPostService {
+        async fn posts_entities(&self, _posts: Vec<Post>) -> DResult<Vec<EPost>> {
+            match &self.behavior {
+                EntityBehavior::Success(posts) => Ok(posts.clone()),
+                EntityBehavior::Error => Err("db error".into()),
+            }
+        }
+    }
+
+    fn empty_request(
+        post_service: Arc<dyn PostService>,
+        entity_post_service: Arc<dyn EntityPostService>,
+    ) -> PostsRequestContent {
+        PostsRequestContent {
+            filter: Filter {
+                search_query: None,
+                author_id: None,
+                tag_id: None,
+            },
+            offset: None,
+            limit: None,
+            post_service,
+            entity_post_service,
+        }
+    }
+
+    fn sample_author(editor: u8, id: u64) -> SAuthor {
+        SAuthor {
+            id,
+            base: BaseAuthor {
+                slug: "john".into(),
+                first_name: None,
+                middle_name: None,
+                last_name: None,
+                mobile: None,
+                email: None,
+                password_hash: None,
+                registered_at: 0,
+                status: None,
+                image_url: None,
+                editor,
+                blocked: 0,
+                yandex_id: None,
+                telegram_id: None,
+                notification_subscribed: None,
+                override_social_data: 0,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn unauthorized_error_when_token_invalid() {
+        let post_service = Arc::new(MockPostService { behavior: PostBehavior::Success(0) });
+        let entity_post_service = Arc::new(MockEntityPostService { behavior: EntityBehavior::Success(vec![]) });
+        let request = UnpublishedPostsRequestContent {
+            base: empty_request(post_service, entity_post_service),
+            auth_author_future: Box::pin(async { Err(auth::Error::TokenMissing) }),
+        };
+        let result = http_handler_unpublished((request,)).await;
+        assert!(matches!(result, Err(Unauthorized { .. })));
+    }
+
+    #[tokio::test]
+    async fn forbidden_when_author_mismatch() {
+        let post_service = Arc::new(MockPostService { behavior: PostBehavior::Success(0) });
+        let entity_post_service = Arc::new(MockEntityPostService { behavior: EntityBehavior::Success(vec![]) });
+        let request = UnpublishedPostsRequestContent {
+            base: PostsRequestContent {
+                filter: Filter { search_query: None, author_id: Some(2), tag_id: None },
+                offset: None,
+                limit: None,
+                post_service,
+                entity_post_service,
+            },
+            auth_author_future: Box::pin(async { Ok(sample_author(0, 1)) }),
+        };
+        let result = http_handler_unpublished((request,)).await;
+        assert!(matches!(result, Err(Forbidden)));
+    }
+
+    #[tokio::test]
+    async fn database_error_from_post_service() {
+        let post_service = Arc::new(MockPostService { behavior: PostBehavior::Error });
+        let entity_post_service = Arc::new(MockEntityPostService { behavior: EntityBehavior::Success(vec![]) });
+        let result = http_handler((empty_request(post_service, entity_post_service),)).await;
+        assert!(matches!(result, Err(DatabaseError { .. })));
+    }
+
+    #[tokio::test]
+    async fn database_error_from_entity_service() {
+        let post_service = Arc::new(MockPostService { behavior: PostBehavior::Success(0) });
+        let entity_post_service = Arc::new(MockEntityPostService { behavior: EntityBehavior::Error });
+        let result = http_handler((empty_request(post_service, entity_post_service),)).await;
+        assert!(matches!(result, Err(DatabaseError { .. })));
+    }
+
+    #[tokio::test]
+    async fn success_returns_posts() {
+        let post_service = Arc::new(MockPostService { behavior: PostBehavior::Success(0) });
+        let entity_post_service = Arc::new(MockEntityPostService { behavior: EntityBehavior::Success(vec![]) });
+        let result = http_handler((empty_request(post_service, entity_post_service),)).await;
+        assert!(matches!(result, Ok(_)));
+    }
+}

--- a/blog-server-services/src/utils/html.rs
+++ b/blog-server-services/src/utils/html.rs
@@ -29,3 +29,26 @@ pub fn clean(src: &str) -> String {
 pub fn to_plain(src: &str) -> String {
     html2text::from_read(src.as_bytes(), usize::MAX)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_strips_disallowed_tags() {
+        let input = "<p>Hello<script>bad()</script><video controls class='article-img' src='v.mp4'></video></p>";
+        let cleaned = clean(input);
+        assert!(!cleaned.contains("script"));
+        assert!(cleaned.contains("<video"));
+        assert!(cleaned.contains("article-img"));
+    }
+
+    #[test]
+    fn to_plain_removes_html_tags() {
+        let input = "<p>Hello <b>World</b></p>";
+        let plain = to_plain(input);
+        assert!(plain.contains("Hello"));
+        assert!(plain.contains("World"));
+        assert!(!plain.contains("<"));
+    }
+}

--- a/blog-server-services/src/utils/time_utils.rs
+++ b/blog-server-services/src/utils/time_utils.rs
@@ -6,3 +6,22 @@ pub fn now_as_secs() -> u64 {
         .unwrap_or_default()
         .as_secs()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_as_secs_is_current_time() {
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let ts = now_as_secs();
+        let after = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(ts >= before && ts <= after);
+    }
+}

--- a/blog-server-services/src/utils/transliteration.rs
+++ b/blog-server-services/src/utils/transliteration.rs
@@ -38,3 +38,45 @@ pub fn ru_to_latin_single(value: String, case_option: TranslitOption) -> Transli
         original: value,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ru_to_latin_preserves_original() {
+        let values = vec![String::from("Привет")];
+        let result = ru_to_latin(values, TranslitOption::Original);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].transliterated, "Privet");
+        assert_eq!(result[0].original, "Привет");
+    }
+
+    #[test]
+    fn ru_to_latin_to_lowercase() {
+        let values = vec![String::from("ПрИвЕт")];
+        let result = ru_to_latin(values, TranslitOption::ToLowerCase);
+        assert_eq!(result[0].transliterated, "privet");
+        assert_eq!(result[0].original, "ПрИвЕт");
+    }
+
+    #[test]
+    fn ru_to_latin_empty_input() {
+        let result = ru_to_latin(vec![], TranslitOption::Original);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn ru_to_latin_single_handles_empty_string() {
+        let result = ru_to_latin_single(String::new(), TranslitOption::Original);
+        assert_eq!(result.transliterated, "");
+        assert_eq!(result.original, "");
+    }
+
+    #[test]
+    fn ru_to_latin_single_to_lowercase() {
+        let result = ru_to_latin_single(String::from("ПрИвЕт"), TranslitOption::ToLowerCase);
+        assert_eq!(result.transliterated, "privet");
+        assert_eq!(result.original, "ПрИвЕт");
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for slug utilities and page processor
- cover transliteration, HTML sanitization, and time utilities
- exercise author endpoint behavior across success and failure paths

## Testing
- `SITE_URL=http://example.com JWT_SECRET=secret SERVER_ADDRESS=127.0.0.1:3000 PG_URL=postgres://localhost RABBIT_URL=amqp://localhost TELEGRAM_BOT_TOKEN=token cargo test`
- `SITE_URL=http://example.com JWT_SECRET=secret SERVER_ADDRESS=127.0.0.1:3000 PG_URL=postgres://localhost RABBIT_URL=amqp://localhost TELEGRAM_BOT_TOKEN=token cargo test -p blog-server-api -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6896ee45fb1c8320bcfa22373537e37a