### PR TITLE
feat: add openai chat endpoint

### DIFF
--- a/blog-generic/src/entities/chat.rs
+++ b/blog-generic/src/entities/chat.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatQuestion {
+    pub question: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatAnswer {
+    pub answer: String,
+}

--- a/blog-generic/src/entities/mod.rs
+++ b/blog-generic/src/entities/mod.rs
@@ -14,6 +14,7 @@ mod posts_container;
 mod tag;
 mod tag_container;
 mod total_offset_limit_container;
+mod chat;
 
 pub use author::*;
 pub use author_container::*;
@@ -31,3 +32,4 @@ pub use posts_container::*;
 pub use tag::*;
 pub use tag_container::*;
 pub use total_offset_limit_container::*;
+pub use chat::*;

--- a/blog-server-api/Cargo.toml
+++ b/blog-server-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 ssr = ["blog-ui", "sitemap-rs"]
-yandex = ["reqwest", "blog-ui?/yandex"]
+yandex = ["blog-ui?/yandex"]
 telegram = ["sha2", "hmac", "hex", "blog-ui?/telegram"]
 
 [dependencies.screw-components]
@@ -54,7 +54,7 @@ once_cell = "1.18.0"
 chrono = "0.4.29"
 sitemap-rs = { version = "0.2.0", optional = true }
 validator = { version = "0.16.1" }
-reqwest = { version = "0.11.20", features = ["json"], optional = true }
+reqwest = { version = "0.11.20", features = ["json"] }
 sha2 = { version = "0.10.0", optional = true }
 hmac = { version = "0.12.1", optional = true }
 hex = { version = "0.4.3", optional = true }

--- a/blog-server-api/src/endpoints/chat/handler.rs
+++ b/blog-server-api/src/endpoints/chat/handler.rs
@@ -1,0 +1,179 @@
+use blog_generic::entities::{ChatAnswer, PublishType};
+use blog_server_services::traits::author_service::AuthorService;
+use blog_server_services::traits::entity_post_service::EntityPostService;
+use blog_server_services::traits::post_service::{PostService, PostsQuery};
+use once_cell::sync::Lazy;
+use reqwest::Client;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use tokio::sync::Mutex;
+
+use super::request_content::ChatRequestContent;
+use super::response_content_failure::ChatResponseContentFailure;
+use super::response_content_failure::ChatResponseContentFailure::*;
+use super::response_content_success::ChatResponseContentSuccess;
+
+static SESSION_DATA: Lazy<Mutex<HashMap<String, (u8, Vec<Value>)>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub async fn http_handler(
+    (ChatRequestContent {
+        question,
+        post_service,
+        entity_post_service,
+        author_service,
+        session_key,
+    },): (ChatRequestContent,),
+) -> Result<ChatResponseContentSuccess, ChatResponseContentFailure> {
+    let question = question.map_err(|e| ParamsDecodeError {
+        reason: e.to_string(),
+    })?;
+    let session_key = session_key;
+
+    let posts_total = post_service
+        .posts(PostsQuery::offset_and_limit(&0, &0).publish_type(Some(&PublishType::Published)))
+        .await
+        .map_err(|e| DatabaseError {
+            reason: e.to_string(),
+        })?
+        .total_count;
+    let posts_list = if posts_total > 0 {
+        post_service
+            .posts(
+                PostsQuery::offset_and_limit(&0, &posts_total)
+                    .publish_type(Some(&PublishType::Published)),
+            )
+            .await
+            .map_err(|e| DatabaseError {
+                reason: e.to_string(),
+            })?
+            .posts
+    } else {
+        vec![]
+    };
+    let posts_entities = entity_post_service
+        .posts_entities(posts_list)
+        .await
+        .map_err(|e| DatabaseError {
+            reason: e.to_string(),
+        })?;
+
+    let authors_total = author_service
+        .authors_count()
+        .await
+        .map_err(|e| DatabaseError {
+            reason: e.to_string(),
+        })?;
+    let authors = if authors_total > 0 {
+        author_service
+            .authors(&0, &authors_total)
+            .await
+            .map_err(|e| DatabaseError {
+                reason: e.to_string(),
+            })?
+    } else {
+        vec![]
+    };
+
+    let posts_context = posts_entities
+        .into_iter()
+        .map(|p| {
+            let author_name = format!(
+                "{} {}",
+                p.author.first_name.clone().unwrap_or_default(),
+                p.author.last_name.clone().unwrap_or_default()
+            );
+            let author_display = if author_name.trim().is_empty() {
+                p.author.slug.clone()
+            } else {
+                author_name
+            };
+            let tags = p.joined_tags_string(", ");
+            let tags_display = if tags.is_empty() {
+                String::new()
+            } else {
+                format!(" [tags: {}]", tags)
+            };
+            format!(
+                "Post: {} by {}{} - {}",
+                p.title, author_display, tags_display, p.summary
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let authors_context = authors
+        .into_iter()
+        .map(|a| {
+            format!(
+                "Author {} - {} {}",
+                a.base.slug,
+                a.base.first_name.unwrap_or_default(),
+                a.base.last_name.unwrap_or_default()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let system_message = json!({
+        "role": "system",
+        "content": "You strictly answer only about the provided blog posts and authors. If asked anything else, respond with 'I can only answer questions about the blog'. Keep answers under 50 words.",
+    });
+
+    let messages = {
+        let mut sessions = SESSION_DATA.lock().await;
+        let session = sessions
+            .entry(session_key.clone())
+            .or_insert((0u8, Vec::new()));
+        if session.0 >= 5 {
+            return Err(SessionLimitReached);
+        }
+        session.0 += 1;
+        if session.1.is_empty() {
+            session.1.push(json!({
+                "role": "user",
+                "content": format!("Posts:\n{}\n\nAuthors:\n{}", posts_context, authors_context),
+            }));
+        }
+        let mut msgs = vec![system_message];
+        msgs.extend(session.1.clone());
+        let q_msg = json!({ "role": "user", "content": question.question.clone() });
+        session.1.push(q_msg.clone());
+        msgs.push(q_msg);
+        msgs
+    };
+
+    let client = Client::new();
+    let body = json!({
+        "model": "gpt-4o-mini",
+        "max_tokens": 100,
+        "messages": messages,
+    });
+    let response = client
+        .post("https://api.openai.com/v1/chat/completions")
+        .bearer_auth(crate::OPENAI_API_KEY)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| OpenAiError {
+            reason: e.to_string(),
+        })?;
+    let value: serde_json::Value = response.json().await.map_err(|e| OpenAiError {
+        reason: e.to_string(),
+    })?;
+    let answer = value["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap_or("Couldn't get an answer")
+        .to_string();
+
+    {
+        let mut sessions = SESSION_DATA.lock().await;
+        if let Some(session) = sessions.get_mut(&session_key) {
+            session
+                .1
+                .push(json!({ "role": "assistant", "content": answer.clone() }));
+        }
+    }
+
+    Ok(ChatAnswer { answer }.into())
+}

--- a/blog-server-api/src/endpoints/chat/mod.rs
+++ b/blog-server-api/src/endpoints/chat/mod.rs
@@ -1,0 +1,6 @@
+mod handler;
+mod request_content;
+mod response_content_failure;
+mod response_content_success;
+
+pub use handler::*;

--- a/blog-server-api/src/endpoints/chat/request_content.rs
+++ b/blog-server-api/src/endpoints/chat/request_content.rs
@@ -1,0 +1,51 @@
+use crate::extensions::Resolve;
+use blog_generic::entities::ChatQuestion;
+use blog_server_services::traits::{
+    author_service::AuthorService, entity_post_service::EntityPostService,
+    post_service::PostService,
+};
+use hyper::header::{ACCEPT_LANGUAGE, USER_AGENT};
+use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
+use screw_components::dyn_result::DResult;
+use std::sync::Arc;
+
+pub struct ChatRequestContent {
+    pub(super) question: DResult<ChatQuestion>,
+    pub(super) post_service: Arc<dyn PostService>,
+    pub(super) entity_post_service: Arc<dyn EntityPostService>,
+    pub(super) author_service: Arc<dyn AuthorService>,
+    pub(super) session_key: String,
+}
+
+impl<Extensions> ApiRequestContent<Extensions> for ChatRequestContent
+where
+    Extensions: Resolve<Arc<dyn PostService>>
+        + Resolve<Arc<dyn EntityPostService>>
+        + Resolve<Arc<dyn AuthorService>>,
+{
+    type Data = ChatQuestion;
+
+    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
+        let headers = &origin_content.http_parts.headers;
+        let ip = headers
+            .get("X-Forwarded-For")
+            .or_else(|| headers.get("X-Real-IP"))
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("0.0.0.0");
+        let ua = headers
+            .get(USER_AGENT)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("unknown");
+        let lang = headers
+            .get(ACCEPT_LANGUAGE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("unknown");
+        Self {
+            question: origin_content.data_result,
+            post_service: origin_content.extensions.resolve(),
+            entity_post_service: origin_content.extensions.resolve(),
+            author_service: origin_content.extensions.resolve(),
+            session_key: format!("{}|{}|{}", ip, ua, lang),
+        }
+    }
+}

--- a/blog-server-api/src/endpoints/chat/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/chat/response_content_failure.rs
@@ -1,0 +1,56 @@
+use hyper::StatusCode;
+use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+
+pub enum ChatResponseContentFailure {
+    DatabaseError { reason: String },
+    ParamsDecodeError { reason: String },
+    OpenAiError { reason: String },
+    SessionLimitReached,
+}
+
+impl ApiResponseContentBase for ChatResponseContentFailure {
+    fn status_code(&self) -> &'static StatusCode {
+        match self {
+            ChatResponseContentFailure::DatabaseError { .. } => &StatusCode::INTERNAL_SERVER_ERROR,
+            ChatResponseContentFailure::ParamsDecodeError { .. } => &StatusCode::BAD_REQUEST,
+            ChatResponseContentFailure::OpenAiError { .. } => &StatusCode::INTERNAL_SERVER_ERROR,
+            ChatResponseContentFailure::SessionLimitReached => &StatusCode::TOO_MANY_REQUESTS,
+        }
+    }
+}
+
+impl ApiResponseContentFailure for ChatResponseContentFailure {
+    fn identifier(&self) -> &'static str {
+        match self {
+            ChatResponseContentFailure::DatabaseError { .. } => "CHAT_DATABASE_ERROR",
+            ChatResponseContentFailure::ParamsDecodeError { .. } => "CHAT_PARAMS_ERROR",
+            ChatResponseContentFailure::OpenAiError { .. } => "CHAT_OPENAI_ERROR",
+            ChatResponseContentFailure::SessionLimitReached => "CHAT_SESSION_LIMIT_REACHED",
+        }
+    }
+
+    fn reason(&self) -> Option<String> {
+        Some(match self {
+            ChatResponseContentFailure::DatabaseError { reason } => {
+                if cfg!(debug_assertions) {
+                    format!("database error: {}", reason)
+                } else {
+                    "internal database error".to_string()
+                }
+            }
+            ChatResponseContentFailure::ParamsDecodeError { reason } => {
+                format!("params error: {}", reason)
+            }
+            ChatResponseContentFailure::OpenAiError { reason } => {
+                if cfg!(debug_assertions) {
+                    format!("openai error: {}", reason)
+                } else {
+                    "internal openai error".to_string()
+                }
+            }
+            ChatResponseContentFailure::SessionLimitReached => {
+                "session question limit reached".to_string()
+            }
+        })
+    }
+}

--- a/blog-server-api/src/endpoints/chat/response_content_success.rs
+++ b/blog-server-api/src/endpoints/chat/response_content_success.rs
@@ -1,0 +1,36 @@
+use blog_generic::entities::ChatAnswer;
+use hyper::StatusCode;
+use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+
+#[derive(Debug, Clone)]
+pub struct ChatResponseContentSuccess {
+    chat_answer: ChatAnswer,
+}
+
+impl From<ChatAnswer> for ChatResponseContentSuccess {
+    fn from(chat_answer: ChatAnswer) -> Self {
+        ChatResponseContentSuccess { chat_answer }
+    }
+}
+
+impl ApiResponseContentBase for ChatResponseContentSuccess {
+    fn status_code(&self) -> &'static StatusCode {
+        &StatusCode::OK
+    }
+}
+
+impl ApiResponseContentSuccess for ChatResponseContentSuccess {
+    type Data = ChatAnswer;
+
+    fn identifier(&self) -> &'static str {
+        "CHAT_SUCCESS"
+    }
+
+    fn description(&self) -> Option<String> {
+        Some("ai chat success".to_string())
+    }
+
+    fn data(&self) -> &Self::Data {
+        &self.chat_answer
+    }
+}

--- a/blog-server-api/src/endpoints/mod.rs
+++ b/blog-server-api/src/endpoints/mod.rs
@@ -11,6 +11,7 @@ pub mod create_comment;
 pub mod create_post;
 pub mod delete_comment;
 pub mod delete_post;
+pub mod chat;
 pub mod login;
 pub mod post;
 pub mod post_recommendation;

--- a/blog-server-api/src/main.rs
+++ b/blog-server-api/src/main.rs
@@ -16,6 +16,7 @@ const SERVER_ADDRESS: &'static str = env!("SERVER_ADDRESS"); // 127.0.0.1:3000
 const PG_URL: &'static str = env!("PG_URL"); // postgres://postgres:postgres@localhost:5432/blog
 const RABBIT_URL: &'static str = env!("RABBIT_URL"); // amqp://guest:guest@localhost:5672/
 const TELEGRAM_BOT_TOKEN: &'static str = env!("TELEGRAM_BOT_TOKEN"); // XXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXX
+const OPENAI_API_KEY: &'static str = env!("OPENAI_API_KEY"); // OpenAI API key
 
 #[tokio::main]
 async fn main() -> screw_components::dyn_result::DResult<()> {

--- a/blog-server-api/src/router.rs
+++ b/blog-server-api/src/router.rs
@@ -212,6 +212,11 @@ pub fn make_router<Extensions: ExtensionsProviderType>(
                 })
                 .route(
                     route::first::Route::with_method(&hyper::Method::POST)
+                        .and_path("/chat")
+                        .and_handler(chat::http_handler),
+                )
+                .route(
+                    route::first::Route::with_method(&hyper::Method::POST)
                         .and_path("/login")
                         .and_handler(login::http_handler),
                 )


### PR DESCRIPTION
## Summary
- add compile-time OpenAI API key
- extend chat request with IP-based session tracking and remember previous dialogue
- fetch all posts and authors with tags and ask GPT-4o mini using a concise system prompt

## Testing
- `SITE_URL=example JWT_SECRET=secret SERVER_ADDRESS=127.0.0.1 PG_URL=postgres:// RABBIT_URL=amqp:// TELEGRAM_BOT_TOKEN=token OPENAI_API_KEY=dummy /root/.cargo/bin/cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a20e4d2a6c83208adf462b2c6c22a9