### PR TITLE
Add robots.txt, canonical/og:url, and sitemap listing pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "no-referrer-when-downgrade" always;
 
-    location ~* ^(?!/(?:sitemap\.xml|index\.html)$).+\.[a-z0-9]+$ {
+    location ~* ^(?!/(?:sitemap\.xml|robots\.txt|index\.html)$).+\.[a-z0-9]+$ {
         limit_req zone=static burst=15 nodelay;
         limit_req_status 429;
         

--- a/blog-server-api/src/endpoints/mod.rs
+++ b/blog-server-api/src/endpoints/mod.rs
@@ -19,6 +19,8 @@ pub mod post_recommendation;
 pub mod post_update_recommended;
 pub mod posts;
 #[cfg(feature = "ssr")]
+mod robots_handler;
+#[cfg(feature = "ssr")]
 mod sitemap_handler;
 pub mod tag;
 #[cfg(feature = "telegram")]
@@ -31,5 +33,7 @@ pub mod yandex_login;
 
 #[cfg(feature = "ssr")]
 pub use client_handler::*;
+#[cfg(feature = "ssr")]
+pub use robots_handler::*;
 #[cfg(feature = "ssr")]
 pub use sitemap_handler::*;

--- a/blog-server-api/src/endpoints/robots_handler.rs
+++ b/blog-server-api/src/endpoints/robots_handler.rs
@@ -1,0 +1,32 @@
+use screw_core::request::*;
+use screw_core::response::*;
+use screw_core::routing::*;
+
+// Served via nginx exclusion -> proxied to the server so the absolute
+// `Sitemap:` URL can be built from the runtime SITE_URL.
+pub async fn robots_handler<Extensions>(
+    _: router::RoutedRequest<Request<Extensions>>,
+) -> Response {
+    let body = format!(
+        "User-agent: *\n\
+         Allow: /\n\
+         Disallow: /settings\n\
+         Disallow: /post/new\n\
+         Disallow: /post/edit/\n\
+         Disallow: /posts/unpublished\n\
+         Disallow: /posts/my/unpublished\n\
+         Disallow: /posts/hidden\n\
+         Disallow: /posts/search\n\
+         Disallow: /authors/search\n\
+         \n\
+         Sitemap: {site_url}/sitemap.xml\n",
+        site_url = &*crate::SITE_URL,
+    );
+
+    Response {
+        http: hyper::Response::builder()
+            .header("Content-Type", "text/plain; charset=utf-8")
+            .body(screw_core::body::full(body))
+            .unwrap(),
+    }
+}

--- a/blog-server-api/src/endpoints/sitemap_handler.rs
+++ b/blog-server-api/src/endpoints/sitemap_handler.rs
@@ -32,7 +32,28 @@ pub async fn sitemap_handler<Extensions: Resolve<Arc<dyn PostService>>>(
         .map(|p| p.posts)
         .unwrap_or_else(|_| vec![]);
 
-    let mut urls = posts
+    let now = DateTime::from_naive_utc_and_offset(
+        chrono::Utc::now().naive_utc(),
+        FixedOffset::east_opt(0).unwrap(),
+    );
+
+    // Static listing pages are otherwise absent from the sitemap.
+    let mut urls = vec![
+        Url::builder(format!("{site_url}/", site_url = &*crate::SITE_URL))
+            .last_modified(now)
+            .change_frequency(ChangeFrequency::Daily)
+            .priority(1.0)
+            .build()
+            .unwrap(),
+        Url::builder(format!("{site_url}/authors", site_url = &*crate::SITE_URL))
+            .last_modified(now)
+            .change_frequency(ChangeFrequency::Weekly)
+            .priority(0.7)
+            .build()
+            .unwrap(),
+    ];
+
+    urls.extend(posts
         .into_iter()
         .map(|post| {
             Url::builder(format!(
@@ -47,12 +68,12 @@ pub async fn sitemap_handler<Extensions: Resolve<Arc<dyn PostService>>>(
                     .naive_utc(),
                 FixedOffset::east_opt(0).unwrap(),
             ))
-            .change_frequency(ChangeFrequency::Daily)
+            .change_frequency(ChangeFrequency::Weekly)
             .priority(1.0)
             .build()
             .unwrap()
         })
-        .collect::<Vec<Url>>();
+        .collect::<Vec<Url>>());
     urls.truncate(RECORDS_LIMIT);
 
     let url_set: UrlSet = UrlSet::new(urls).unwrap();

--- a/blog-server-api/src/endpoints/sitemap_handler.rs
+++ b/blog-server-api/src/endpoints/sitemap_handler.rs
@@ -37,7 +37,6 @@ pub async fn sitemap_handler<Extensions: Resolve<Arc<dyn PostService>>>(
         FixedOffset::east_opt(0).unwrap(),
     );
 
-    // Static listing pages are otherwise absent from the sitemap.
     let mut urls = vec![
         Url::builder(format!("{site_url}/", site_url = &*crate::SITE_URL))
             .last_modified(now)

--- a/blog-server-api/src/router.rs
+++ b/blog-server-api/src/router.rs
@@ -54,6 +54,11 @@ pub fn make_router<Extensions: ExtensionsProviderType>()
     #[cfg(feature = "ssr")]
     let sitemap_handler = sitemap_handler;
 
+    #[cfg(not(feature = "ssr"))]
+    let robots_handler = not_found_fallback_handler;
+    #[cfg(feature = "ssr")]
+    let robots_handler = robots_handler;
+
     #[cfg(not(feature = "yandex"))]
     let yandex_handler = api_not_found_fallback_handler;
     #[cfg(feature = "yandex")]
@@ -246,6 +251,11 @@ pub fn make_router<Extensions: ExtensionsProviderType>()
             route::first::Route::with_method(&hyper::Method::GET)
                 .and_path("/sitemap.xml")
                 .and_handler(sitemap_handler),
+        )
+        .route(
+            route::first::Route::with_method(&hyper::Method::GET)
+                .and_path("/robots.txt")
+                .and_handler(robots_handler),
         )
     })
 }


### PR DESCRIPTION
- Serve /robots.txt from the server (with an absolute Sitemap: directive
  built from SITE_URL) and exclude it from the nginx static try_files so it
  proxies through instead of returning 404. Disallow admin/search routes.
- Inject a self-referencing canonical URL and og:url into every SSR page in
  client_handler (preserving only the `page` pagination query).
- Include the homepage and authors listing in sitemap.xml, which previously
  only contained post URLs.