### PR TITLE
Update blog-server to screw 0.1.0

### DIFF
--- a/blog-server-api/Cargo.toml
+++ b/blog-server-api/Cargo.toml
@@ -14,26 +14,26 @@ tikitko = ["blog-ui?/tikitko"]
 
 [dependencies.screw-components]
 git = "https://github.com/Tikitko/screw.git"
-tag = "0.0.2"
+tag = "0.1.0"
 #path = "../../screw/screw-components"
 package = "screw-components"
 
 [dependencies.screw-core]
 git = "https://github.com/Tikitko/screw.git"
-tag = "0.0.2"
+tag = "0.1.0"
 #path = "../../screw/screw-core"
 package = "screw-core"
 
 [dependencies.screw-api]
 git = "https://github.com/Tikitko/screw.git"
-tag = "0.0.2"
+tag = "0.1.0"
 #path = "../../screw/screw-api"
 package = "screw-api"
 features = ["json"]
 
 [dependencies.screw-ws]
 git = "https://github.com/Tikitko/screw.git"
-tag = "0.0.2"
+tag = "0.1.0"
 #path = "../../screw/screw-ws"
 package = "screw-ws"
 

--- a/blog-server-api/src/endpoints/author/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author/response_content_failure.rs
@@ -8,13 +8,13 @@ pub enum AuthorResponseContentFailure {
 }
 
 impl ApiResponseContentBase for AuthorResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             AuthorResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            AuthorResponseContentFailure::SlugEmpty => &StatusCode::BAD_REQUEST,
-            AuthorResponseContentFailure::NotFound => &StatusCode::NOT_FOUND,
+            AuthorResponseContentFailure::SlugEmpty => StatusCode::BAD_REQUEST,
+            AuthorResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
         }
     }
 }

--- a/blog-server-api/src/endpoints/author/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author/response_content_success.rs
@@ -19,8 +19,8 @@ impl Into<AuthorResponseContentSuccess> for ServiceAuthor {
 }
 
 impl ApiResponseContentBase for AuthorResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/author_block/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author_block/response_content_failure.rs
@@ -9,17 +9,17 @@ pub enum AuthorBlockResponseContentFailure {
 }
 
 impl ApiResponseContentBase for AuthorBlockResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             AuthorBlockResponseContentFailure::Unauthorized { reason: _ } => {
-                &StatusCode::UNAUTHORIZED
+                StatusCode::UNAUTHORIZED
             }
-            AuthorBlockResponseContentFailure::Forbidden => &StatusCode::FORBIDDEN,
+            AuthorBlockResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
             AuthorBlockResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
             AuthorBlockResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
         }
     }

--- a/blog-server-api/src/endpoints/author_block/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author_block/response_content_success.rs
@@ -5,8 +5,8 @@ use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
 pub struct AuthorBlockResponseContentSuccess;
 
 impl ApiResponseContentBase for AuthorBlockResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/author_me/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author_me/response_content_failure.rs
@@ -6,9 +6,9 @@ pub enum AuthorMeResponseContentFailure {
 }
 
 impl ApiResponseContentBase for AuthorMeResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
-            AuthorMeResponseContentFailure::Unauthorized { reason: _ } => &StatusCode::UNAUTHORIZED,
+            AuthorMeResponseContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
         }
     }
 }

--- a/blog-server-api/src/endpoints/author_me/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author_me/response_content_success.rs
@@ -19,8 +19,8 @@ impl Into<AuthorMeResponseContentSuccess> for ServiceAuthor {
 }
 
 impl ApiResponseContentBase for AuthorMeResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/author_override_social_data/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author_override_social_data/response_content_failure.rs
@@ -8,14 +8,14 @@ pub enum AuthorOverrideSocialDataResponseContentFailure {
 }
 
 impl ApiResponseContentBase for AuthorOverrideSocialDataResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             AuthorOverrideSocialDataResponseContentFailure::Unauthorized { reason: _ } => {
-                &StatusCode::UNAUTHORIZED
+                StatusCode::UNAUTHORIZED
             }
-            AuthorOverrideSocialDataResponseContentFailure::Forbidden => &StatusCode::FORBIDDEN,
+            AuthorOverrideSocialDataResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
             AuthorOverrideSocialDataResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
         }
     }

--- a/blog-server-api/src/endpoints/author_override_social_data/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author_override_social_data/response_content_success.rs
@@ -11,8 +11,8 @@ impl Into<AuthorOverrideSocialDataResponseContentSuccess> for () {
 }
 
 impl ApiResponseContentBase for AuthorOverrideSocialDataResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/author_subscribe/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/response_content_failure.rs
@@ -10,19 +10,19 @@ pub enum AuthorSubscribeResponseContentFailure {
 }
 
 impl ApiResponseContentBase for AuthorSubscribeResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             AuthorSubscribeResponseContentFailure::Unauthorized { reason: _ } => {
-                &StatusCode::UNAUTHORIZED
+                StatusCode::UNAUTHORIZED
             }
-            AuthorSubscribeResponseContentFailure::Forbidden => &StatusCode::FORBIDDEN,
+            AuthorSubscribeResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
             AuthorSubscribeResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
             AuthorSubscribeResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
-            AuthorSubscribeResponseContentFailure::NotFound => &StatusCode::NOT_FOUND,
+            AuthorSubscribeResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
         }
     }
 }

--- a/blog-server-api/src/endpoints/author_subscribe/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/response_content_success.rs
@@ -5,8 +5,8 @@ use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
 pub struct AuthorSubscribeRequestContentSuccess;
 
 impl ApiResponseContentBase for AuthorSubscribeRequestContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/authors/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/authors/response_content_failure.rs
@@ -6,10 +6,10 @@ pub enum AuthorsResponseContentFailure {
 }
 
 impl ApiResponseContentBase for AuthorsResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             AuthorsResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
         }
     }

--- a/blog-server-api/src/endpoints/authors/response_content_success.rs
+++ b/blog-server-api/src/endpoints/authors/response_content_success.rs
@@ -14,8 +14,8 @@ impl Into<AuthorsResponseContentSuccess> for AuthorsContainer {
 }
 
 impl ApiResponseContentBase for AuthorsResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/chatgpt/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/chatgpt/response_content_failure.rs
@@ -9,12 +9,12 @@ pub enum ChatResponseContentFailure {
 }
 
 impl ApiResponseContentBase for ChatResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
-            ChatResponseContentFailure::DatabaseError { .. } => &StatusCode::INTERNAL_SERVER_ERROR,
-            ChatResponseContentFailure::ParamsDecodeError { .. } => &StatusCode::BAD_REQUEST,
-            ChatResponseContentFailure::OpenAiError { .. } => &StatusCode::INTERNAL_SERVER_ERROR,
-            ChatResponseContentFailure::SessionLimitReached => &StatusCode::TOO_MANY_REQUESTS,
+            ChatResponseContentFailure::DatabaseError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ChatResponseContentFailure::ParamsDecodeError { .. } => StatusCode::BAD_REQUEST,
+            ChatResponseContentFailure::OpenAiError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ChatResponseContentFailure::SessionLimitReached => StatusCode::TOO_MANY_REQUESTS,
         }
     }
 }

--- a/blog-server-api/src/endpoints/chatgpt/response_content_success.rs
+++ b/blog-server-api/src/endpoints/chatgpt/response_content_success.rs
@@ -14,8 +14,8 @@ impl From<ChatAnswer> for ChatResponseContentSuccess {
 }
 
 impl ApiResponseContentBase for ChatResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/client_handler.rs
+++ b/blog-server-api/src/endpoints/client_handler.rs
@@ -95,7 +95,7 @@ pub async fn client_handler<
 
     let rendered = server_renderer(
         render_path(request.path.as_str()),
-        request.query,
+        request.query.as_map().clone(),
         app_content,
     )
     .render()

--- a/blog-server-api/src/endpoints/comments/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/comments/response_content_failure.rs
@@ -7,13 +7,13 @@ pub enum CommentsResponseContentFailure {
 }
 
 impl ApiResponseContentBase for CommentsResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             CommentsResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
             CommentsResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
         }
     }

--- a/blog-server-api/src/endpoints/comments/response_content_success.rs
+++ b/blog-server-api/src/endpoints/comments/response_content_success.rs
@@ -14,8 +14,8 @@ impl Into<CommentsResponseContentSuccess> for CommentsContainer {
 }
 
 impl ApiResponseContentBase for CommentsResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/create_comment/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/create_comment/response_content_failure.rs
@@ -10,15 +10,15 @@ pub enum CreateCommentContentFailure {
 }
 
 impl ApiResponseContentBase for CreateCommentContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             CreateCommentContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            CreateCommentContentFailure::ValidationError { reason: _ } => &StatusCode::BAD_REQUEST,
-            CreateCommentContentFailure::Unauthorized { reason: _ } => &StatusCode::UNAUTHORIZED,
-            CreateCommentContentFailure::InsertFailed => &StatusCode::INTERNAL_SERVER_ERROR,
-            CreateCommentContentFailure::CreatingForbidden => &StatusCode::FORBIDDEN,
+            CreateCommentContentFailure::ValidationError { reason: _ } => StatusCode::BAD_REQUEST,
+            CreateCommentContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
+            CreateCommentContentFailure::InsertFailed => StatusCode::INTERNAL_SERVER_ERROR,
+            CreateCommentContentFailure::CreatingForbidden => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/blog-server-api/src/endpoints/create_comment/response_content_success.rs
+++ b/blog-server-api/src/endpoints/create_comment/response_content_success.rs
@@ -5,8 +5,8 @@ use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
 pub struct CreateCommentContentSuccess;
 
 impl ApiResponseContentBase for CreateCommentContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/create_post/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/create_post/response_content_failure.rs
@@ -10,15 +10,15 @@ pub enum CreatePostContentFailure {
 }
 
 impl ApiResponseContentBase for CreatePostContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             CreatePostContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            CreatePostContentFailure::ValidationError { reason: _ } => &StatusCode::BAD_REQUEST,
-            CreatePostContentFailure::Unauthorized { reason: _ } => &StatusCode::UNAUTHORIZED,
-            CreatePostContentFailure::InsertFailed => &StatusCode::INTERNAL_SERVER_ERROR,
-            CreatePostContentFailure::CreatingForbidden => &StatusCode::FORBIDDEN,
+            CreatePostContentFailure::ValidationError { reason: _ } => StatusCode::BAD_REQUEST,
+            CreatePostContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
+            CreatePostContentFailure::InsertFailed => StatusCode::INTERNAL_SERVER_ERROR,
+            CreatePostContentFailure::CreatingForbidden => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/blog-server-api/src/endpoints/create_post/response_content_success.rs
+++ b/blog-server-api/src/endpoints/create_post/response_content_success.rs
@@ -16,8 +16,8 @@ impl Into<CreatePostContentSuccess> for Post {
 }
 
 impl ApiResponseContentBase for CreatePostContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/delete_comment/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/delete_comment/response_content_failure.rs
@@ -10,19 +10,19 @@ pub enum DeleteCommentResponseContentFailure {
 }
 
 impl ApiResponseContentBase for DeleteCommentResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             DeleteCommentResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            DeleteCommentResponseContentFailure::NotFound => &StatusCode::NOT_FOUND,
+            DeleteCommentResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
             DeleteCommentResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
             DeleteCommentResponseContentFailure::Unauthorized { reason: _ } => {
-                &StatusCode::UNAUTHORIZED
+                StatusCode::UNAUTHORIZED
             }
-            DeleteCommentResponseContentFailure::EditingForbidden => &StatusCode::FORBIDDEN,
+            DeleteCommentResponseContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/blog-server-api/src/endpoints/delete_comment/response_content_success.rs
+++ b/blog-server-api/src/endpoints/delete_comment/response_content_success.rs
@@ -5,8 +5,8 @@ use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
 pub struct DeleteCommentResponseContentSuccess;
 
 impl ApiResponseContentBase for DeleteCommentResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/delete_post/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/delete_post/response_content_failure.rs
@@ -10,19 +10,19 @@ pub enum DeletePostResponseContentFailure {
 }
 
 impl ApiResponseContentBase for DeletePostResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             DeletePostResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            DeletePostResponseContentFailure::NotFound => &StatusCode::NOT_FOUND,
+            DeletePostResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
             DeletePostResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
             DeletePostResponseContentFailure::Unauthorized { reason: _ } => {
-                &StatusCode::UNAUTHORIZED
+                StatusCode::UNAUTHORIZED
             }
-            DeletePostResponseContentFailure::EditingForbidden => &StatusCode::FORBIDDEN,
+            DeletePostResponseContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/blog-server-api/src/endpoints/delete_post/response_content_success.rs
+++ b/blog-server-api/src/endpoints/delete_post/response_content_success.rs
@@ -5,8 +5,8 @@ use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
 pub struct DeletePostResponseContentSuccess;
 
 impl ApiResponseContentBase for DeletePostResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/login/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/login/response_content_failure.rs
@@ -13,24 +13,22 @@ pub enum LoginResponseContentFailure {
 }
 
 impl ApiResponseContentBase for LoginResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             LoginResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            LoginResponseContentFailure::ParamsDecodeError { reason: _ } => {
-                &StatusCode::BAD_REQUEST
-            }
-            LoginResponseContentFailure::SlugEmpty => &StatusCode::BAD_REQUEST,
-            LoginResponseContentFailure::NotFound => &StatusCode::NOT_FOUND,
+            LoginResponseContentFailure::ParamsDecodeError { reason: _ } => StatusCode::BAD_REQUEST,
+            LoginResponseContentFailure::SlugEmpty => StatusCode::BAD_REQUEST,
+            LoginResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
             LoginResponseContentFailure::PasswordVerificationError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            LoginResponseContentFailure::WrongPassword => &StatusCode::FORBIDDEN,
+            LoginResponseContentFailure::WrongPassword => StatusCode::FORBIDDEN,
             LoginResponseContentFailure::TokenGeneratingError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            LoginResponseContentFailure::Blocked => &StatusCode::FORBIDDEN,
+            LoginResponseContentFailure::Blocked => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/blog-server-api/src/endpoints/login/response_content_success.rs
+++ b/blog-server-api/src/endpoints/login/response_content_success.rs
@@ -16,8 +16,8 @@ impl Into<LoginResponseContentSuccess> for String {
 }
 
 impl ApiResponseContentBase for LoginResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/post/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/post/response_content_failure.rs
@@ -8,13 +8,13 @@ pub enum PostResponseContentFailure {
 }
 
 impl ApiResponseContentBase for PostResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             PostResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            PostResponseContentFailure::NotFound => &StatusCode::NOT_FOUND,
-            PostResponseContentFailure::IncorrectIdFormat { reason: _ } => &StatusCode::BAD_REQUEST,
+            PostResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
+            PostResponseContentFailure::IncorrectIdFormat { reason: _ } => StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/blog-server-api/src/endpoints/post/response_content_success.rs
+++ b/blog-server-api/src/endpoints/post/response_content_success.rs
@@ -16,8 +16,8 @@ impl Into<PostResponseContentSuccess> for Post {
 }
 
 impl ApiResponseContentBase for PostResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/post_recommendation/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/post_recommendation/response_content_failure.rs
@@ -8,14 +8,14 @@ pub enum PostRecommendationResponseContentFailure {
 }
 
 impl ApiResponseContentBase for PostRecommendationResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             PostRecommendationResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            PostRecommendationResponseContentFailure::NotFound => &StatusCode::NOT_FOUND,
+            PostRecommendationResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
             PostRecommendationResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
         }
     }

--- a/blog-server-api/src/endpoints/post_recommendation/response_content_success.rs
+++ b/blog-server-api/src/endpoints/post_recommendation/response_content_success.rs
@@ -16,8 +16,8 @@ impl Into<PostRecommendationResponseContentSuccess> for Post {
 }
 
 impl ApiResponseContentBase for PostRecommendationResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/post_update_recommended/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/post_update_recommended/response_content_failure.rs
@@ -9,17 +9,17 @@ pub enum PostUpdateRecommendedResponseContentFailure {
 }
 
 impl ApiResponseContentBase for PostUpdateRecommendedResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             PostUpdateRecommendedResponseContentFailure::Unauthorized { reason: _ } => {
-                &StatusCode::UNAUTHORIZED
+                StatusCode::UNAUTHORIZED
             }
-            PostUpdateRecommendedResponseContentFailure::Forbidden => &StatusCode::FORBIDDEN,
+            PostUpdateRecommendedResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
             PostUpdateRecommendedResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
             PostUpdateRecommendedResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
         }
     }

--- a/blog-server-api/src/endpoints/post_update_recommended/response_content_success.rs
+++ b/blog-server-api/src/endpoints/post_update_recommended/response_content_success.rs
@@ -5,8 +5,8 @@ use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
 pub struct PostUpdateRecommendedResponseContentSuccess;
 
 impl ApiResponseContentBase for PostUpdateRecommendedResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/posts/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/posts/response_content_failure.rs
@@ -8,13 +8,13 @@ pub enum PostsResponseContentFailure {
 }
 
 impl ApiResponseContentBase for PostsResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             PostsResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            PostsResponseContentFailure::Unauthorized { reason: _ } => &StatusCode::UNAUTHORIZED,
-            PostsResponseContentFailure::Forbidden => &StatusCode::FORBIDDEN,
+            PostsResponseContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
+            PostsResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/blog-server-api/src/endpoints/posts/response_content_success.rs
+++ b/blog-server-api/src/endpoints/posts/response_content_success.rs
@@ -14,8 +14,8 @@ impl Into<PostsResponseContentSuccess> for PostsContainer {
 }
 
 impl ApiResponseContentBase for PostsResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/tag/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/tag/response_content_failure.rs
@@ -8,13 +8,13 @@ pub enum TagResponseContentFailure {
 }
 
 impl ApiResponseContentBase for TagResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             TagResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            TagResponseContentFailure::NotFound => &StatusCode::NOT_FOUND,
-            TagResponseContentFailure::IncorrectIdFormat { reason: _ } => &StatusCode::BAD_REQUEST,
+            TagResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
+            TagResponseContentFailure::IncorrectIdFormat { reason: _ } => StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/blog-server-api/src/endpoints/tag/response_content_success.rs
+++ b/blog-server-api/src/endpoints/tag/response_content_success.rs
@@ -17,8 +17,8 @@ impl Into<TagResponseContentSuccess> for ServiceTag {
 }
 
 impl ApiResponseContentBase for TagResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/telegram_login/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/telegram_login/response_content_failure.rs
@@ -9,19 +9,19 @@ pub enum LoginTelegramResponseContentFailure {
 }
 
 impl ApiResponseContentBase for LoginTelegramResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             LoginTelegramResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
             LoginTelegramResponseContentFailure::ParamsDecodeError { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
             LoginTelegramResponseContentFailure::TokenGeneratingError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
             LoginTelegramResponseContentFailure::TelegramError { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
         }
     }

--- a/blog-server-api/src/endpoints/telegram_login/response_content_success.rs
+++ b/blog-server-api/src/endpoints/telegram_login/response_content_success.rs
@@ -16,8 +16,8 @@ impl Into<LoginTelegramResponseContentSuccess> for String {
 }
 
 impl ApiResponseContentBase for LoginTelegramResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/update_minimal_author/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/update_minimal_author/response_content_failure.rs
@@ -9,18 +9,18 @@ pub enum UpdateMinimalAuthorContentFailure {
 }
 
 impl ApiResponseContentBase for UpdateMinimalAuthorContentFailure {
-    fn status_code(&self) -> &'static hyper::StatusCode {
+    fn status_code(&self) -> hyper::StatusCode {
         match self {
             UpdateMinimalAuthorContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
             UpdateMinimalAuthorContentFailure::ValidationError { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
             UpdateMinimalAuthorContentFailure::Unauthorized { reason: _ } => {
-                &StatusCode::UNAUTHORIZED
+                StatusCode::UNAUTHORIZED
             }
-            UpdateMinimalAuthorContentFailure::EditingForbidden => &StatusCode::FORBIDDEN,
+            UpdateMinimalAuthorContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/blog-server-api/src/endpoints/update_minimal_author/response_content_success.rs
+++ b/blog-server-api/src/endpoints/update_minimal_author/response_content_success.rs
@@ -11,8 +11,8 @@ impl Into<UpdateMinimalAuthorContentSuccess> for () {
 }
 
 impl ApiResponseContentBase for UpdateMinimalAuthorContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/update_post/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/update_post/response_content_failure.rs
@@ -11,16 +11,16 @@ pub enum UpdatePostContentFailure {
 }
 
 impl ApiResponseContentBase for UpdatePostContentFailure {
-    fn status_code(&self) -> &'static hyper::StatusCode {
+    fn status_code(&self) -> hyper::StatusCode {
         match self {
             UpdatePostContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            UpdatePostContentFailure::PostNotFound => &StatusCode::BAD_REQUEST,
-            UpdatePostContentFailure::ValidationError { reason: _ } => &StatusCode::BAD_REQUEST,
-            UpdatePostContentFailure::Unauthorized { reason: _ } => &StatusCode::UNAUTHORIZED,
-            UpdatePostContentFailure::EditingForbidden => &StatusCode::FORBIDDEN,
-            UpdatePostContentFailure::IncorrectIdFormat { reason: _ } => &StatusCode::BAD_REQUEST,
+            UpdatePostContentFailure::PostNotFound => StatusCode::BAD_REQUEST,
+            UpdatePostContentFailure::ValidationError { reason: _ } => StatusCode::BAD_REQUEST,
+            UpdatePostContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
+            UpdatePostContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
+            UpdatePostContentFailure::IncorrectIdFormat { reason: _ } => StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/blog-server-api/src/endpoints/update_post/response_content_success.rs
+++ b/blog-server-api/src/endpoints/update_post/response_content_success.rs
@@ -16,8 +16,8 @@ impl Into<UpdatePostContentSuccess> for Post {
 }
 
 impl ApiResponseContentBase for UpdatePostContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/update_secondary_author/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/update_secondary_author/response_content_failure.rs
@@ -9,18 +9,18 @@ pub enum UpdateSecondaryAuthorContentFailure {
 }
 
 impl ApiResponseContentBase for UpdateSecondaryAuthorContentFailure {
-    fn status_code(&self) -> &'static hyper::StatusCode {
+    fn status_code(&self) -> hyper::StatusCode {
         match self {
             UpdateSecondaryAuthorContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
             UpdateSecondaryAuthorContentFailure::ValidationError { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
             UpdateSecondaryAuthorContentFailure::Unauthorized { reason: _ } => {
-                &StatusCode::UNAUTHORIZED
+                StatusCode::UNAUTHORIZED
             }
-            UpdateSecondaryAuthorContentFailure::EditingForbidden => &StatusCode::FORBIDDEN,
+            UpdateSecondaryAuthorContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/blog-server-api/src/endpoints/update_secondary_author/response_content_success.rs
+++ b/blog-server-api/src/endpoints/update_secondary_author/response_content_success.rs
@@ -11,8 +11,8 @@ impl Into<UpdateSecondaryAuthorContentSuccess> for () {
 }
 
 impl ApiResponseContentBase for UpdateSecondaryAuthorContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/endpoints/yandex_login/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/yandex_login/response_content_failure.rs
@@ -9,20 +9,18 @@ pub enum LoginYandexResponseContentFailure {
 }
 
 impl ApiResponseContentBase for LoginYandexResponseContentFailure {
-    fn status_code(&self) -> &'static StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
             LoginYandexResponseContentFailure::DatabaseError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
             LoginYandexResponseContentFailure::ParamsDecodeError { reason: _ } => {
-                &StatusCode::BAD_REQUEST
+                StatusCode::BAD_REQUEST
             }
             LoginYandexResponseContentFailure::TokenGeneratingError { reason: _ } => {
-                &StatusCode::INTERNAL_SERVER_ERROR
+                StatusCode::INTERNAL_SERVER_ERROR
             }
-            LoginYandexResponseContentFailure::YandexError { reason: _ } => {
-                &StatusCode::BAD_REQUEST
-            }
+            LoginYandexResponseContentFailure::YandexError { reason: _ } => StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/blog-server-api/src/endpoints/yandex_login/response_content_success.rs
+++ b/blog-server-api/src/endpoints/yandex_login/response_content_success.rs
@@ -16,8 +16,8 @@ impl Into<LoginYandexResponseContentSuccess> for String {
 }
 
 impl ApiResponseContentBase for LoginYandexResponseContentSuccess {
-    fn status_code(&self) -> &'static StatusCode {
-        &StatusCode::OK
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
     }
 }
 

--- a/blog-server-api/src/router.rs
+++ b/blog-server-api/src/router.rs
@@ -22,8 +22,8 @@ async fn not_found_fallback_handler<Extensions>(
 struct NotFoundResponseContentFailure;
 
 impl ApiResponseContentBase for NotFoundResponseContentFailure {
-    fn status_code(&self) -> &'static hyper::StatusCode {
-        &hyper::StatusCode::NOT_FOUND
+    fn status_code(&self) -> hyper::StatusCode {
+        hyper::StatusCode::NOT_FOUND
     }
 }
 
@@ -74,6 +74,7 @@ pub fn make_router<Extensions: ExtensionsProviderType>()
             "/api",
             JsonApiMiddlewareConverter {
                 pretty_printed: cfg!(debug_assertions),
+                ..Default::default()
             },
             |r| {
                 r.scoped("/author", |r| {

--- a/blog-server-services/Cargo.toml
+++ b/blog-server-services/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 
 [dependencies.screw-components]
 git = "https://github.com/Tikitko/screw.git"
-tag = "0.0.2"
+tag = "0.1.0"
 #path = "../../screw/screw-components"
 package = "screw-components"
 


### PR DESCRIPTION
Bump the screw crates pin from tag 0.0.2 to tag 0.1.0 and adapt to its breaking API changes: ApiResponseContentBase::status_code now returns StatusCode by value instead of &'static StatusCode, JsonApiMiddlewareConverter gained a max_body_size field, and RoutedRequest.query is now a lazily-parsed Query type instead of a HashMap.