### PR TITLE
Move auth into a middleware and derive the API request/response impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "blog-server-api",
+    "blog-server-api-macros",
     "blog-server-services",
     "blog-ui"
 ]

--- a/blog-server-api-macros/Cargo.toml
+++ b/blog-server-api-macros/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "blog-server-api-macros"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/blog-server-api-macros/src/failure.rs
+++ b/blog-server-api-macros/src/failure.rs
@@ -1,0 +1,215 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, Ident, LitStr, Variant, parse_macro_input};
+
+struct Spec {
+    auth: bool,
+    status: Option<Ident>,
+    reason: Option<String>,
+    debug_reason: Option<String>,
+}
+
+impl Spec {
+    fn empty() -> Self {
+        Self {
+            auth: false,
+            status: None,
+            reason: None,
+            debug_reason: None,
+        }
+    }
+
+    fn sugar(&mut self, status: &str, reason: &str, debug_reason: Option<&str>) {
+        self.status = Some(Ident::new(status, proc_macro2::Span::call_site()));
+        self.reason = Some(reason.to_owned());
+        self.debug_reason = debug_reason.map(str::to_owned);
+    }
+}
+
+fn upper_snake(name: &str) -> String {
+    let mut out = String::new();
+    for (index, character) in name.char_indices() {
+        if character.is_uppercase() && index != 0 {
+            out.push('_');
+        }
+        out.extend(character.to_uppercase());
+    }
+    out
+}
+
+fn parse_spec(variant: &Variant) -> syn::Result<Spec> {
+    let mut spec = Spec::empty();
+    let mut found = false;
+
+    for attr in &variant.attrs {
+        if !attr.path().is_ident("failure") {
+            continue;
+        }
+        found = true;
+        attr.parse_nested_meta(|meta| {
+            let key = meta
+                .path
+                .get_ident()
+                .ok_or_else(|| meta.error("expected an identifier"))?
+                .to_string();
+            match key.as_str() {
+                "auth" => spec.auth = true,
+                "database" => spec.sugar(
+                    "INTERNAL_SERVER_ERROR",
+                    "internal database error",
+                    Some("database error: {reason}"),
+                ),
+                "validation" => spec.sugar("BAD_REQUEST", "validation error: {reason}", None),
+                "params" => spec.sugar("BAD_REQUEST", "params error: {reason}", None),
+                "token" => spec.sugar(
+                    "INTERNAL_SERVER_ERROR",
+                    "internal token generating error",
+                    Some("token generating error: {reason}"),
+                ),
+                "not_found" => {
+                    let entity: LitStr = meta.value()?.parse()?;
+                    spec.sugar(
+                        "NOT_FOUND",
+                        &format!("{} record not found in database", entity.value()),
+                        None,
+                    );
+                }
+                "incorrect_id" => {
+                    let entity: LitStr = meta.value()?.parse()?;
+                    spec.sugar(
+                        "BAD_REQUEST",
+                        &format!(
+                            "incorrect value provided for {} ID: {{reason}}",
+                            entity.value()
+                        ),
+                        None,
+                    );
+                }
+                "status" => spec.status = Some(meta.value()?.parse()?),
+                "reason" => spec.reason = Some(meta.value()?.parse::<LitStr>()?.value()),
+                "debug_reason" => {
+                    spec.debug_reason = Some(meta.value()?.parse::<LitStr>()?.value())
+                }
+                other => return Err(meta.error(format!("unknown failure option `{other}`"))),
+            }
+            Ok(())
+        })?;
+    }
+
+    if !found {
+        return Err(syn::Error::new_spanned(
+            variant,
+            "every variant needs a #[failure(...)] attribute",
+        ));
+    }
+    if !spec.auth && spec.status.is_none() {
+        return Err(syn::Error::new_spanned(
+            variant,
+            "a non-auth variant needs a status, either directly or through a shorthand",
+        ));
+    }
+    Ok(spec)
+}
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let Data::Enum(data) = input.data else {
+        return syn::Error::new_spanned(name, "ApiFailure only applies to enums")
+            .to_compile_error()
+            .into();
+    };
+
+    let mut status_arms = Vec::new();
+    let mut identifier_arms = Vec::new();
+    let mut reason_arms = Vec::new();
+    let mut auth_variant = None;
+
+    for variant in &data.variants {
+        let spec = match parse_spec(variant) {
+            Ok(spec) => spec,
+            Err(error) => return error.to_compile_error().into(),
+        };
+        let variant_name = &variant.ident;
+
+        if spec.auth {
+            auth_variant = Some(variant_name.clone());
+            status_arms.push(quote! { Self::#variant_name(inner) => inner.status_code() });
+            identifier_arms.push(quote! { Self::#variant_name(inner) => inner.identifier() });
+            reason_arms.push(quote! { Self::#variant_name(inner) => inner.reason() });
+            continue;
+        }
+
+        let status = spec.status.unwrap();
+        let identifier = upper_snake(&variant_name.to_string());
+        let ignore = match variant.fields {
+            Fields::Unit => quote! {},
+            _ => quote! { { .. } },
+        };
+        status_arms.push(quote! {
+            Self::#variant_name #ignore => hyper::StatusCode::#status
+        });
+        identifier_arms.push(quote! {
+            Self::#variant_name #ignore => #identifier
+        });
+
+        let bindings = match &variant.fields {
+            Fields::Unit => quote! {},
+            Fields::Named(named) => {
+                let idents = named.named.iter().map(|field| &field.ident);
+                quote! { { #(#idents),* } }
+            }
+            Fields::Unnamed(_) => {
+                return syn::Error::new_spanned(
+                    variant,
+                    "tuple variants are only supported for the auth variant",
+                )
+                .to_compile_error()
+                .into();
+            }
+        };
+        let reason = spec.reason.unwrap_or_default();
+        let body = match spec.debug_reason {
+            Some(debug_reason) => quote! {
+                Some(if cfg!(debug_assertions) {
+                    format!(#debug_reason)
+                } else {
+                    format!(#reason)
+                })
+            },
+            None => quote! { Some(format!(#reason)) },
+        };
+        reason_arms.push(quote! { Self::#variant_name #bindings => #body });
+    }
+
+    let from_auth = auth_variant.map(|variant_name| {
+        quote! {
+            impl From<crate::utils::auth_middleware::AuthRejection> for #name {
+                fn from(value: crate::utils::auth_middleware::AuthRejection) -> Self {
+                    Self::#variant_name(value)
+                }
+            }
+        }
+    });
+
+    quote! {
+        impl screw_api::response::ApiResponseContentBase for #name {
+            fn status_code(&self) -> hyper::StatusCode {
+                match self { #(#status_arms),* }
+            }
+        }
+
+        impl screw_api::response::ApiResponseContentFailure for #name {
+            fn identifier(&self) -> &'static str {
+                match self { #(#identifier_arms),* }
+            }
+            fn reason(&self) -> Option<String> {
+                match self { #(#reason_arms),* }
+            }
+        }
+
+        #from_auth
+    }
+    .into()
+}

--- a/blog-server-api-macros/src/lib.rs
+++ b/blog-server-api-macros/src/lib.rs
@@ -1,0 +1,20 @@
+use proc_macro::TokenStream;
+
+mod failure;
+mod request;
+mod success;
+
+#[proc_macro_derive(ApiFailure, attributes(failure))]
+pub fn api_failure(input: TokenStream) -> TokenStream {
+    failure::derive(input)
+}
+
+#[proc_macro_derive(ApiSuccess, attributes(success))]
+pub fn api_success(input: TokenStream) -> TokenStream {
+    success::derive(input)
+}
+
+#[proc_macro_derive(ApiRequest, attributes(request))]
+pub fn api_request(input: TokenStream) -> TokenStream {
+    request::derive(input)
+}

--- a/blog-server-api-macros/src/request.rs
+++ b/blog-server-api-macros/src/request.rs
@@ -1,0 +1,158 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, LitStr, parse_macro_input};
+
+enum Source {
+    Extension,
+    Data,
+    Path(String),
+    Query(String),
+}
+
+fn inner_of(ty: &syn::Type, wrapper: &str) -> Option<syn::Type> {
+    let syn::Type::Path(path) = ty else {
+        return None;
+    };
+    let segment = path.path.segments.last()?;
+    if segment.ident != wrapper {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        syn::GenericArgument::Type(inner) => Some(inner.clone()),
+        _ => None,
+    })
+}
+
+fn is_string(ty: &syn::Type) -> bool {
+    matches!(ty, syn::Type::Path(path)
+        if path.path.segments.last().is_some_and(|s| s.ident == "String"))
+}
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let Data::Struct(data) = input.data else {
+        return syn::Error::new_spanned(name, "ApiRequest only applies to structs")
+            .to_compile_error()
+            .into();
+    };
+    let fields = match data.fields {
+        Fields::Named(fields) => fields.named,
+        Fields::Unit => Default::default(),
+        Fields::Unnamed(_) => {
+            return syn::Error::new_spanned(name, "ApiRequest needs named fields")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let mut assignments = Vec::new();
+    let mut bounds = Vec::new();
+    let mut data_type = None;
+
+    for field in &fields {
+        let field_name = field.ident.as_ref().unwrap();
+        let mut source = None;
+
+        for attr in &field.attrs {
+            if !attr.path().is_ident("request") {
+                continue;
+            }
+            let parsed = attr.parse_nested_meta(|meta| {
+                let key = meta
+                    .path
+                    .get_ident()
+                    .ok_or_else(|| meta.error("expected an identifier"))?
+                    .to_string();
+                match key.as_str() {
+                    "extension" => source = Some(Source::Extension),
+                    "data" => source = Some(Source::Data),
+                    "path" => source = Some(Source::Path(meta.value()?.parse::<LitStr>()?.value())),
+                    "query" => {
+                        source = Some(Source::Query(meta.value()?.parse::<LitStr>()?.value()))
+                    }
+                    other => return Err(meta.error(format!("unknown request option `{other}`"))),
+                }
+                Ok(())
+            });
+            if let Err(error) = parsed {
+                return error.to_compile_error().into();
+            }
+        }
+
+        let Some(source) = source else {
+            return syn::Error::new_spanned(
+                field,
+                "every field needs #[request(extension)], #[request(data)], \
+                 #[request(path = \"...\")] or #[request(query = \"...\")]",
+            )
+            .to_compile_error()
+            .into();
+        };
+
+        let ty = &field.ty;
+        let expression = match source {
+            Source::Extension => {
+                bounds.push(quote! { crate::extensions::Resolve<#ty> });
+                quote! { origin_content.extensions.resolve() }
+            }
+            Source::Data => {
+                let Some(inner) = inner_of(ty, "DResult") else {
+                    return syn::Error::new_spanned(field, "a data field must be a `DResult<T>`")
+                        .to_compile_error()
+                        .into();
+                };
+                data_type = Some(inner);
+                quote! { origin_content.data_result }
+            }
+            Source::Path(key) => match inner_of(ty, "Option") {
+                Some(_) => quote! { origin_content.path.get(#key).map(|n| n.to_owned()) },
+                None => quote! {
+                    origin_content.path.get(#key).map(|n| n.to_owned()).unwrap_or_default()
+                },
+            },
+            Source::Query(key) => {
+                let inner = inner_of(ty, "Option");
+                match inner {
+                    Some(inner) if is_string(&inner) => {
+                        quote! { origin_content.query.get(#key).map(|n| n.to_owned()) }
+                    }
+                    Some(_) => quote! {
+                        origin_content.query.get(#key).and_then(|v| v.parse().ok())
+                    },
+                    None => {
+                        return syn::Error::new_spanned(
+                            field,
+                            "a query field must be an `Option<T>`",
+                        )
+                        .to_compile_error()
+                        .into();
+                    }
+                }
+            }
+        };
+        assignments.push(quote! { #field_name: #expression });
+    }
+
+    let data_type = data_type.map(|ty| quote! { #ty }).unwrap_or(quote! { () });
+    let where_clause = (!bounds.is_empty()).then(|| quote! { where Extensions: #(#bounds)+* });
+
+    quote! {
+        impl<Extensions> screw_api::request::ApiRequestContent<Extensions> for #name
+        #where_clause
+        {
+            type Data = #data_type;
+
+            fn create(
+                origin_content: screw_api::request::ApiRequestOriginContent<Self::Data, Extensions>,
+            ) -> Self {
+                Self { #(#assignments),* }
+            }
+        }
+    }
+    .into()
+}

--- a/blog-server-api-macros/src/success.rs
+++ b/blog-server-api-macros/src/success.rs
@@ -1,0 +1,97 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, LitStr, parse_macro_input};
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let Data::Struct(data) = input.data else {
+        return syn::Error::new_spanned(name, "ApiSuccess only applies to structs")
+            .to_compile_error()
+            .into();
+    };
+
+    let mut identifier = None;
+    let mut description = None;
+
+    for attr in &input.attrs {
+        if !attr.path().is_ident("success") {
+            continue;
+        }
+        let parsed = attr.parse_nested_meta(|meta| {
+            let key = meta
+                .path
+                .get_ident()
+                .ok_or_else(|| meta.error("expected an identifier"))?
+                .to_string();
+            match key.as_str() {
+                "found" => identifier = Some("FOUND"),
+                "created" => identifier = Some("CREATED"),
+                "ok" => identifier = Some("OK"),
+                "description" => {
+                    description = Some(meta.value()?.parse::<LitStr>()?.value());
+                }
+                other => return Err(meta.error(format!("unknown success option `{other}`"))),
+            }
+            Ok(())
+        });
+        if let Err(error) = parsed {
+            return error.to_compile_error().into();
+        }
+    }
+
+    let Some(identifier) = identifier else {
+        return syn::Error::new_spanned(
+            name,
+            "expected one of #[success(found)], #[success(created)] or #[success(ok)]",
+        )
+        .to_compile_error()
+        .into();
+    };
+    let Some(description) = description else {
+        return syn::Error::new_spanned(name, "expected #[success(description = \"...\")]")
+            .to_compile_error()
+            .into();
+    };
+
+    let (data_type, data_body) = match &data.fields {
+        Fields::Unit => (quote! { () }, quote! { &() }),
+        Fields::Named(named) if named.named.len() == 1 => {
+            let field = named.named.first().unwrap();
+            let field_name = &field.ident;
+            let field_type = &field.ty;
+            (quote! { #field_type }, quote! { &self.#field_name })
+        }
+        _ => {
+            return syn::Error::new_spanned(
+                name,
+                "expected a unit struct or a struct with exactly one field holding the data",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    quote! {
+        impl screw_api::response::ApiResponseContentBase for #name {
+            fn status_code(&self) -> hyper::StatusCode {
+                hyper::StatusCode::OK
+            }
+        }
+
+        impl screw_api::response::ApiResponseContentSuccess for #name {
+            type Data = #data_type;
+            fn identifier(&self) -> &'static str {
+                #identifier
+            }
+            fn description(&self) -> Option<String> {
+                Some(#description.to_string())
+            }
+            fn data(&self) -> &Self::Data {
+                #data_body
+            }
+        }
+    }
+    .into()
+}

--- a/blog-server-api/Cargo.toml
+++ b/blog-server-api/Cargo.toml
@@ -31,12 +31,6 @@ tag = "0.1.0"
 package = "screw-api"
 features = ["json"]
 
-[dependencies.screw-ws]
-git = "https://github.com/Tikitko/screw.git"
-tag = "0.1.0"
-#path = "../../screw/screw-ws"
-package = "screw-ws"
-
 [dependencies.blog-ui]
 path = "../blog-ui"
 default-features = false
@@ -49,6 +43,7 @@ tag = "1.0.0"
 features = ["validator"]
 
 [dependencies]
+blog-server-api-macros = { path = "../blog-server-api-macros" }
 blog-server-services = { path = "../blog-server-services" }
 tokio = { version = "1.27.0", features = ["full"] }
 hyper = { version = "1.8.1", features = ["full"] }

--- a/blog-server-api/src/endpoints/author/request_content.rs
+++ b/blog-server-api/src/endpoints/author/request_content.rs
@@ -1,27 +1,11 @@
-use crate::extensions::Resolve;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::author_service::*;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct AuthorRequestContent {
+    #[request(path = "slug")]
     pub(super) slug: String,
+    #[request(extension)]
     pub(super) author_service: Arc<dyn AuthorService>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for AuthorRequestContent
-where
-    Extensions: Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            slug: origin_content
-                .path
-                .get("slug")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            author_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/author/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author/response_content_failure.rs
@@ -1,48 +1,11 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum AuthorResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
-    SlugEmpty,
+    #[failure(not_found = "author")]
     NotFound,
-}
-
-impl ApiResponseContentBase for AuthorResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            AuthorResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            AuthorResponseContentFailure::SlugEmpty => StatusCode::BAD_REQUEST,
-            AuthorResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for AuthorResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            AuthorResponseContentFailure::DatabaseError { reason: _ } => "AUTHOR_DATABASE_ERROR",
-            AuthorResponseContentFailure::SlugEmpty => "AUTHOR_SLUG_EMPTY",
-            AuthorResponseContentFailure::NotFound => "AUTHOR_NOT_FOUND",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            AuthorResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            AuthorResponseContentFailure::SlugEmpty => {
-                "author slug is empty in request URL".to_string()
-            }
-            AuthorResponseContentFailure::NotFound => {
-                "author record not found in database".to_string()
-            }
-        })
-    }
+    #[failure(status = BAD_REQUEST, reason = "author slug is empty in request URL")]
+    SlugEmpty,
 }

--- a/blog-server-api/src/endpoints/author/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author/response_content_success.rs
@@ -1,41 +1,19 @@
 use blog_generic::entities::AuthorContainer;
+use blog_server_api_macros::ApiSuccess;
 use blog_server_services::traits::author_service::Author as ServiceAuthor;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(found, description = "author record found")]
 pub struct AuthorResponseContentSuccess {
     pub(super) container: AuthorContainer,
 }
 
-impl Into<AuthorResponseContentSuccess> for ServiceAuthor {
-    fn into(self) -> AuthorResponseContentSuccess {
+impl From<ServiceAuthor> for AuthorResponseContentSuccess {
+    fn from(value: ServiceAuthor) -> Self {
         AuthorResponseContentSuccess {
             container: AuthorContainer {
-                author: self.into(),
+                author: value.into(),
             },
         }
-    }
-}
-
-impl ApiResponseContentBase for AuthorResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for AuthorResponseContentSuccess {
-    type Data = AuthorContainer;
-
-    fn identifier(&self) -> &'static str {
-        "AUTHOR_FOUND"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("author record found".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
     }
 }

--- a/blog-server-api/src/endpoints/author_block/handler.rs
+++ b/blog-server-api/src/endpoints/author_block/handler.rs
@@ -1,39 +1,29 @@
+use blog_server_services::traits::author_service::Author;
+
 use super::request_content::AuthorBlockRequestContent;
 use super::response_content_failure::AuthorBlockResponseContentFailure;
 use super::response_content_failure::AuthorBlockResponseContentFailure::*;
 use super::response_content_success::AuthorBlockResponseContentSuccess;
 
 pub async fn http_handler_block(
-    (request_content,): (AuthorBlockRequestContent,),
+    (_, request_content): (Author, AuthorBlockRequestContent),
 ) -> Result<AuthorBlockResponseContentSuccess, AuthorBlockResponseContentFailure> {
     http_handler(request_content, 1).await
 }
 
 pub async fn http_handler_unblock(
-    (request_content,): (AuthorBlockRequestContent,),
+    (_, request_content): (Author, AuthorBlockRequestContent),
 ) -> Result<AuthorBlockResponseContentSuccess, AuthorBlockResponseContentFailure> {
     http_handler(request_content, 0).await
 }
 
 async fn http_handler(
-    AuthorBlockRequestContent {
-        id,
-        author_service,
-        auth_author_future,
-    }: AuthorBlockRequestContent,
+    AuthorBlockRequestContent { id, author_service }: AuthorBlockRequestContent,
     is_blocked: u8,
 ) -> Result<AuthorBlockResponseContentSuccess, AuthorBlockResponseContentFailure> {
     let id = id.parse::<u64>().map_err(|e| IncorrectIdFormat {
         reason: e.to_string(),
     })?;
-
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.editor != 1 {
-        return Err(Forbidden);
-    }
 
     author_service
         .set_author_blocked_by_id(&id, &is_blocked)

--- a/blog-server-api/src/endpoints/author_block/request_content.rs
+++ b/blog-server-api/src/endpoints/author_block/request_content.rs
@@ -1,34 +1,11 @@
-use crate::extensions::Resolve;
-use crate::utils::auth;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::author_service::*;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::dyn_fn::DFuture;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct AuthorBlockRequestContent {
+    #[request(path = "id")]
     pub(super) id: String,
+    #[request(extension)]
     pub(super) author_service: Arc<dyn AuthorService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for AuthorBlockRequestContent
-where
-    Extensions: Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            id: origin_content
-                .path
-                .get("id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            author_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/author_block/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author_block/response_content_failure.rs
@@ -1,66 +1,13 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum AuthorBlockResponseContentFailure {
-    Unauthorized { reason: String },
-    Forbidden,
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(incorrect_id = "author")]
     IncorrectIdFormat { reason: String },
-}
-
-impl ApiResponseContentBase for AuthorBlockResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            AuthorBlockResponseContentFailure::Unauthorized { reason: _ } => {
-                StatusCode::UNAUTHORIZED
-            }
-            AuthorBlockResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
-            AuthorBlockResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            AuthorBlockResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-        }
-    }
-}
-
-impl ApiResponseContentFailure for AuthorBlockResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            AuthorBlockResponseContentFailure::Unauthorized { reason: _ } => {
-                "AUTHOR_BLOCK_UNAUTHORIZED"
-            }
-            AuthorBlockResponseContentFailure::Forbidden => "AUTHOR_BLOCK_FORBIDDEN",
-            AuthorBlockResponseContentFailure::DatabaseError { reason: _ } => {
-                "AUTHOR_BLOCK_DATABASE_ERROR"
-            }
-            AuthorBlockResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                "AUTHOR_BLOCK_INCORRECT_ID_FORMAT"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            AuthorBlockResponseContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            AuthorBlockResponseContentFailure::Forbidden => String::from("insufficient rights"),
-            AuthorBlockResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            AuthorBlockResponseContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for author ID: {}", reason)
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/author_block/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author_block/response_content_success.rs
@@ -1,27 +1,5 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "author block state changed")]
 pub struct AuthorBlockResponseContentSuccess;
-
-impl ApiResponseContentBase for AuthorBlockResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for AuthorBlockResponseContentSuccess {
-    type Data = ();
-
-    fn identifier(&self) -> &'static str {
-        "AUTHOR_BLOCK_OK"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("author block state changed".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &()
-    }
-}

--- a/blog-server-api/src/endpoints/author_me/handler.rs
+++ b/blog-server-api/src/endpoints/author_me/handler.rs
@@ -1,15 +1,11 @@
+use blog_server_services::traits::author_service::Author;
+
 use super::request_content::AuthorMeRequestContent;
 use super::response_content_failure::AuthorMeResponseContentFailure;
-use super::response_content_failure::AuthorMeResponseContentFailure::*;
 use super::response_content_success::AuthorMeResponseContentSuccess;
 
 pub async fn http_handler(
-    (AuthorMeRequestContent { auth_author_future },): (AuthorMeRequestContent,),
+    (author, AuthorMeRequestContent): (Author, AuthorMeRequestContent),
 ) -> Result<AuthorMeResponseContentSuccess, AuthorMeResponseContentFailure> {
-    auth_author_future
-        .await
-        .map(|v| v.into())
-        .map_err(|e| Unauthorized {
-            reason: e.to_string(),
-        })
+    Ok(author.into())
 }

--- a/blog-server-api/src/endpoints/author_me/request_content.rs
+++ b/blog-server-api/src/endpoints/author_me/request_content.rs
@@ -1,26 +1,4 @@
-use crate::extensions::Resolve;
-use crate::utils::auth;
-use blog_server_services::traits::author_service::*;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::dyn_fn::DFuture;
-use std::sync::Arc;
+use blog_server_api_macros::ApiRequest;
 
-pub struct AuthorMeRequestContent {
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for AuthorMeRequestContent
-where
-    Extensions: Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
-}
+#[derive(ApiRequest)]
+pub struct AuthorMeRequestContent;

--- a/blog-server-api/src/endpoints/author_me/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author_me/response_content_failure.rs
@@ -1,34 +1,9 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum AuthorMeResponseContentFailure {
-    Unauthorized { reason: String },
-}
-
-impl ApiResponseContentBase for AuthorMeResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            AuthorMeResponseContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for AuthorMeResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            AuthorMeResponseContentFailure::Unauthorized { reason: _ } => "AUTHOR_ME_UNAUTHORIZED",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            AuthorMeResponseContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-        })
-    }
+    #[failure(auth)]
+    Auth(AuthRejection),
 }

--- a/blog-server-api/src/endpoints/author_me/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author_me/response_content_success.rs
@@ -1,41 +1,19 @@
 use blog_generic::entities::AuthorContainer;
+use blog_server_api_macros::ApiSuccess;
 use blog_server_services::traits::author_service::Author as ServiceAuthor;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(found, description = "auth passed and self author profile returned")]
 pub struct AuthorMeResponseContentSuccess {
     container: AuthorContainer,
 }
 
-impl Into<AuthorMeResponseContentSuccess> for ServiceAuthor {
-    fn into(self) -> AuthorMeResponseContentSuccess {
+impl From<ServiceAuthor> for AuthorMeResponseContentSuccess {
+    fn from(value: ServiceAuthor) -> Self {
         AuthorMeResponseContentSuccess {
             container: AuthorContainer {
-                author: self.into(),
+                author: value.into(),
             },
         }
-    }
-}
-
-impl ApiResponseContentBase for AuthorMeResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for AuthorMeResponseContentSuccess {
-    type Data = AuthorContainer;
-
-    fn identifier(&self) -> &'static str {
-        "AUTHOR_ME_OK"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("auth passed and self author profile returned".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
     }
 }

--- a/blog-server-api/src/endpoints/author_override_social_data/handler.rs
+++ b/blog-server-api/src/endpoints/author_override_social_data/handler.rs
@@ -1,44 +1,36 @@
+use blog_server_services::traits::author_service::Author;
+
 use super::request_content::AuthorOverrideSocialDataRequestContent;
 use super::response_content_failure::AuthorOverrideSocialDataResponseContentFailure;
 use super::response_content_failure::AuthorOverrideSocialDataResponseContentFailure::*;
 use super::response_content_success::AuthorOverrideSocialDataResponseContentSuccess;
 
 pub async fn http_handler_enabled(
-    (request_content,): (AuthorOverrideSocialDataRequestContent,),
+    (author, request_content): (Author, AuthorOverrideSocialDataRequestContent),
 ) -> Result<
     AuthorOverrideSocialDataResponseContentSuccess,
     AuthorOverrideSocialDataResponseContentFailure,
 > {
-    http_handler(request_content, 1).await
+    http_handler(author, request_content, 1).await
 }
 
 pub async fn http_handler_disabled(
-    (request_content,): (AuthorOverrideSocialDataRequestContent,),
+    (author, request_content): (Author, AuthorOverrideSocialDataRequestContent),
 ) -> Result<
     AuthorOverrideSocialDataResponseContentSuccess,
     AuthorOverrideSocialDataResponseContentFailure,
 > {
-    http_handler(request_content, 0).await
+    http_handler(author, request_content, 0).await
 }
 
 async fn http_handler(
-    AuthorOverrideSocialDataRequestContent {
-        author_service,
-        auth_author_future,
-    }: AuthorOverrideSocialDataRequestContent,
+    author: Author,
+    AuthorOverrideSocialDataRequestContent { author_service }: AuthorOverrideSocialDataRequestContent,
     override_social_data: u8,
 ) -> Result<
     AuthorOverrideSocialDataResponseContentSuccess,
     AuthorOverrideSocialDataResponseContentFailure,
 > {
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.blocked == 1 {
-        return Err(Forbidden);
-    }
-
     author_service
         .set_author_override_social_data_by_id(&author.id, &override_social_data)
         .await

--- a/blog-server-api/src/endpoints/author_override_social_data/request_content.rs
+++ b/blog-server-api/src/endpoints/author_override_social_data/request_content.rs
@@ -1,28 +1,9 @@
-use crate::extensions::Resolve;
-use crate::utils::auth;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::author_service::*;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::dyn_fn::DFuture;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct AuthorOverrideSocialDataRequestContent {
+    #[request(extension)]
     pub(super) author_service: Arc<dyn AuthorService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for AuthorOverrideSocialDataRequestContent
-where
-    Extensions: Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            author_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/author_override_social_data/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author_override_social_data/response_content_failure.rs
@@ -1,60 +1,11 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum AuthorOverrideSocialDataResponseContentFailure {
-    Unauthorized { reason: String },
-    Forbidden,
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
-}
-
-impl ApiResponseContentBase for AuthorOverrideSocialDataResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            AuthorOverrideSocialDataResponseContentFailure::Unauthorized { reason: _ } => {
-                StatusCode::UNAUTHORIZED
-            }
-            AuthorOverrideSocialDataResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
-            AuthorOverrideSocialDataResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-        }
-    }
-}
-
-impl ApiResponseContentFailure for AuthorOverrideSocialDataResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            AuthorOverrideSocialDataResponseContentFailure::Unauthorized { reason: _ } => {
-                "AUTHOR_OVERRIDE_SOCIAL_DATA_UNAUTHORIZED"
-            }
-            AuthorOverrideSocialDataResponseContentFailure::Forbidden => {
-                "AUTHOR_OVERRIDE_SOCIAL_DATA_FORBIDDEN"
-            }
-            AuthorOverrideSocialDataResponseContentFailure::DatabaseError { reason: _ } => {
-                "AUTHOR_OVERRIDE_SOCIAL_DATA_DATABASE_ERROR"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            AuthorOverrideSocialDataResponseContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            AuthorOverrideSocialDataResponseContentFailure::Forbidden => {
-                String::from("insufficient rights")
-            }
-            AuthorOverrideSocialDataResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/author_override_social_data/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author_override_social_data/response_content_success.rs
@@ -1,33 +1,11 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "author block state changed")]
 pub struct AuthorOverrideSocialDataResponseContentSuccess;
 
-impl Into<AuthorOverrideSocialDataResponseContentSuccess> for () {
-    fn into(self) -> AuthorOverrideSocialDataResponseContentSuccess {
+impl From<()> for AuthorOverrideSocialDataResponseContentSuccess {
+    fn from(_value: ()) -> Self {
         AuthorOverrideSocialDataResponseContentSuccess
-    }
-}
-
-impl ApiResponseContentBase for AuthorOverrideSocialDataResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for AuthorOverrideSocialDataResponseContentSuccess {
-    type Data = ();
-
-    fn identifier(&self) -> &'static str {
-        "AUTHOR_OVERRIDE_SOCIAL_DATA_OK"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("author block state changed".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &()
     }
 }

--- a/blog-server-api/src/endpoints/author_subscribe/handler.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/handler.rs
@@ -1,34 +1,32 @@
+use blog_server_services::traits::author_service::Author;
+
 use super::request_content::AuthorSubscribeRequestContent;
 use super::response_content_failure::AuthorSubscribeResponseContentFailure;
 use super::response_content_failure::AuthorSubscribeResponseContentFailure::*;
 use super::response_content_success::AuthorSubscribeRequestContentSuccess;
 
 pub async fn http_handler_subscribe(
-    (request_content,): (AuthorSubscribeRequestContent,),
+    (author, request_content): (Author, AuthorSubscribeRequestContent),
 ) -> Result<AuthorSubscribeRequestContentSuccess, AuthorSubscribeResponseContentFailure> {
-    http_handler(request_content, 1).await
+    http_handler(author, request_content, 1).await
 }
 
 pub async fn http_handler_unsubscribe(
-    (request_content,): (AuthorSubscribeRequestContent,),
+    (author, request_content): (Author, AuthorSubscribeRequestContent),
 ) -> Result<AuthorSubscribeRequestContentSuccess, AuthorSubscribeResponseContentFailure> {
-    http_handler(request_content, 0).await
+    http_handler(author, request_content, 0).await
 }
 
 async fn http_handler(
+    logged_in_author: Author,
     AuthorSubscribeRequestContent {
         id,
         social_service,
         author_service,
-        auth_author_future,
     }: AuthorSubscribeRequestContent,
     subscribe: u8,
 ) -> Result<AuthorSubscribeRequestContentSuccess, AuthorSubscribeResponseContentFailure> {
     let id = id.parse::<u64>().map_err(|e| IncorrectIdFormat {
-        reason: e.to_string(),
-    })?;
-
-    let logged_in_author = auth_author_future.await.map_err(|e| Unauthorized {
         reason: e.to_string(),
     })?;
 

--- a/blog-server-api/src/endpoints/author_subscribe/request_content.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/request_content.rs
@@ -1,37 +1,14 @@
-use crate::extensions::Resolve;
-use crate::utils::auth;
-use blog_server_services::traits::author_service::{Author, AuthorService};
+use blog_server_api_macros::ApiRequest;
+use blog_server_services::traits::author_service::AuthorService;
 use blog_server_services::traits::social_service::SocialService;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::dyn_fn::DFuture;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct AuthorSubscribeRequestContent {
+    #[request(path = "id")]
     pub(super) id: String,
+    #[request(extension)]
     pub(super) social_service: Arc<dyn SocialService>,
+    #[request(extension)]
     pub(super) author_service: Arc<dyn AuthorService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for AuthorSubscribeRequestContent
-where
-    Extensions: Resolve<Arc<dyn AuthorService>> + Resolve<Arc<dyn SocialService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            id: origin_content
-                .path
-                .get("id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            social_service: origin_content.extensions.resolve(),
-            author_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/author_subscribe/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/response_content_failure.rs
@@ -1,72 +1,17 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum AuthorSubscribeResponseContentFailure {
-    Unauthorized { reason: String },
-    Forbidden,
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
-    IncorrectIdFormat { reason: String },
+    #[failure(not_found = "author")]
     NotFound,
-}
-
-impl ApiResponseContentBase for AuthorSubscribeResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            AuthorSubscribeResponseContentFailure::Unauthorized { reason: _ } => {
-                StatusCode::UNAUTHORIZED
-            }
-            AuthorSubscribeResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
-            AuthorSubscribeResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            AuthorSubscribeResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-            AuthorSubscribeResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for AuthorSubscribeResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            AuthorSubscribeResponseContentFailure::Unauthorized { reason: _ } => {
-                "AUTHOR_SUBSCRIBE_UNAUTHORIZED"
-            }
-            AuthorSubscribeResponseContentFailure::DatabaseError { reason: _ } => {
-                "AUTHOR_SUBSCRIBE_DATABASE_ERROR"
-            }
-            AuthorSubscribeResponseContentFailure::Forbidden => "AUTHOR_SUBSCRIBE_FORBIDDEN",
-            AuthorSubscribeResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                "AUTHOR_SUBSCRIBE_INCORRECT_ID_FORMAT"
-            }
-            AuthorSubscribeResponseContentFailure::NotFound => "AUTHOR_SUBSCRIBE_NOT_FOUND",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            AuthorSubscribeResponseContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            AuthorSubscribeResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            AuthorSubscribeResponseContentFailure::Forbidden => String::from("insufficient rights"),
-            AuthorSubscribeResponseContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for author ID: {}", reason)
-            }
-            AuthorSubscribeResponseContentFailure::NotFound => {
-                "author record not found in database".to_string()
-            }
-        })
-    }
+    #[failure(incorrect_id = "author")]
+    IncorrectIdFormat { reason: String },
+    #[failure(status = FORBIDDEN, reason = "insufficient rights")]
+    Forbidden,
 }

--- a/blog-server-api/src/endpoints/author_subscribe/response_content_success.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/response_content_success.rs
@@ -1,27 +1,5 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "author notification subscription state changed")]
 pub struct AuthorSubscribeRequestContentSuccess;
-
-impl ApiResponseContentBase for AuthorSubscribeRequestContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for AuthorSubscribeRequestContentSuccess {
-    type Data = ();
-
-    fn identifier(&self) -> &'static str {
-        "AUTHOR_SUBSCRIBE_OK"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("author notification subscription state changed".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &()
-    }
-}

--- a/blog-server-api/src/endpoints/authors/request_content.rs
+++ b/blog-server-api/src/endpoints/authors/request_content.rs
@@ -1,35 +1,15 @@
-use crate::extensions::Resolve;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::author_service::*;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct AuthorsRequestContent {
+    #[request(path = "query")]
     pub(super) query: Option<String>,
+    #[request(query = "offset")]
     pub(super) offset: Option<u64>,
+    #[request(query = "limit")]
     pub(super) limit: Option<u64>,
+    #[request(extension)]
     pub(super) author_service: Arc<dyn AuthorService>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for AuthorsRequestContent
-where
-    Extensions: Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            query: origin_content.path.get("query").map(|n| n.to_owned()),
-            offset: origin_content
-                .query
-                .get("offset")
-                .map(|v| v.parse().ok())
-                .flatten(),
-            limit: origin_content
-                .query
-                .get("limit")
-                .map(|v| v.parse().ok())
-                .flatten(),
-            author_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/authors/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/authors/response_content_failure.rs
@@ -1,36 +1,7 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum AuthorsResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
-}
-
-impl ApiResponseContentBase for AuthorsResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            AuthorsResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-        }
-    }
-}
-
-impl ApiResponseContentFailure for AuthorsResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            AuthorsResponseContentFailure::DatabaseError { reason: _ } => "AUTHORS_DATABASE_ERROR",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            AuthorsResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/authors/response_content_success.rs
+++ b/blog-server-api/src/endpoints/authors/response_content_success.rs
@@ -1,36 +1,14 @@
 use blog_generic::entities::AuthorsContainer;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(found, description = "authors list returned")]
 pub struct AuthorsResponseContentSuccess {
     pub(super) container: AuthorsContainer,
 }
 
-impl Into<AuthorsResponseContentSuccess> for AuthorsContainer {
-    fn into(self) -> AuthorsResponseContentSuccess {
-        AuthorsResponseContentSuccess { container: self }
-    }
-}
-
-impl ApiResponseContentBase for AuthorsResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for AuthorsResponseContentSuccess {
-    type Data = AuthorsContainer;
-
-    fn identifier(&self) -> &'static str {
-        "AUTHORS_OK"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("authors list returned".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
+impl From<AuthorsContainer> for AuthorsResponseContentSuccess {
+    fn from(value: AuthorsContainer) -> Self {
+        AuthorsResponseContentSuccess { container: value }
     }
 }

--- a/blog-server-api/src/endpoints/chatgpt/handler.rs
+++ b/blog-server-api/src/endpoints/chatgpt/handler.rs
@@ -133,7 +133,8 @@ pub async fn http_handler(
     if user_question.is_empty() {
         return Err(ParamsDecodeError {
             reason: "question must not be empty".to_string(),
-        });
+        }
+        .into());
     }
 
     let question_char_count = user_question.chars().count();
@@ -143,7 +144,8 @@ pub async fn http_handler(
                 "question must be at most {} symbols",
                 OPENAI_MAX_QUESTION_CHARS
             ),
-        });
+        }
+        .into());
     }
     let chat_session_id = chat_session_id.map_err(|e| ParamsDecodeError {
         reason: e.to_string(),

--- a/blog-server-api/src/endpoints/chatgpt/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/chatgpt/response_content_failure.rs
@@ -1,56 +1,17 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum ChatResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(params)]
     ParamsDecodeError { reason: String },
+    #[failure(
+        status = INTERNAL_SERVER_ERROR,
+        reason = "internal openai error",
+        debug_reason = "openai error: {reason}"
+    )]
     OpenAiError { reason: String },
+    #[failure(status = TOO_MANY_REQUESTS, reason = "session question limit reached")]
     SessionLimitReached,
-}
-
-impl ApiResponseContentBase for ChatResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            ChatResponseContentFailure::DatabaseError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            ChatResponseContentFailure::ParamsDecodeError { .. } => StatusCode::BAD_REQUEST,
-            ChatResponseContentFailure::OpenAiError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            ChatResponseContentFailure::SessionLimitReached => StatusCode::TOO_MANY_REQUESTS,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for ChatResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            ChatResponseContentFailure::DatabaseError { .. } => "CHAT_DATABASE_ERROR",
-            ChatResponseContentFailure::ParamsDecodeError { .. } => "CHAT_PARAMS_ERROR",
-            ChatResponseContentFailure::OpenAiError { .. } => "CHAT_OPENAI_ERROR",
-            ChatResponseContentFailure::SessionLimitReached => "CHAT_SESSION_LIMIT_REACHED",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            ChatResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            ChatResponseContentFailure::ParamsDecodeError { reason } => {
-                format!("params error: {}", reason)
-            }
-            ChatResponseContentFailure::OpenAiError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("openai error: {}", reason)
-                } else {
-                    "internal openai error".to_string()
-                }
-            }
-            ChatResponseContentFailure::SessionLimitReached => {
-                "session question limit reached".to_string()
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/chatgpt/response_content_success.rs
+++ b/blog-server-api/src/endpoints/chatgpt/response_content_success.rs
@@ -1,8 +1,8 @@
 use blog_generic::entities::ChatAnswer;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "ai chat success")]
 pub struct ChatResponseContentSuccess {
     chat_answer: ChatAnswer,
 }
@@ -10,27 +10,5 @@ pub struct ChatResponseContentSuccess {
 impl From<ChatAnswer> for ChatResponseContentSuccess {
     fn from(chat_answer: ChatAnswer) -> Self {
         ChatResponseContentSuccess { chat_answer }
-    }
-}
-
-impl ApiResponseContentBase for ChatResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for ChatResponseContentSuccess {
-    type Data = ChatAnswer;
-
-    fn identifier(&self) -> &'static str {
-        "CHAT_SUCCESS"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("ai chat success".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.chat_answer
     }
 }

--- a/blog-server-api/src/endpoints/comments/request_content.rs
+++ b/blog-server-api/src/endpoints/comments/request_content.rs
@@ -1,42 +1,18 @@
-use crate::extensions::Resolve;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::comment_service::*;
 use blog_server_services::traits::entity_comment_service::*;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct CommentsRequestContent {
+    #[request(path = "post_id")]
     pub(super) post_id: String,
+    #[request(query = "offset")]
     pub(super) offset: Option<u64>,
+    #[request(query = "limit")]
     pub(super) limit: Option<u64>,
+    #[request(extension)]
     pub(super) comment_service: Arc<dyn CommentService>,
+    #[request(extension)]
     pub(super) entity_comment_service: Arc<dyn EntityCommentService>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for CommentsRequestContent
-where
-    Extensions: Resolve<Arc<dyn CommentService>> + Resolve<Arc<dyn EntityCommentService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            post_id: origin_content
-                .path
-                .get("post_id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            offset: origin_content
-                .query
-                .get("offset")
-                .map(|v| v.parse().ok())
-                .flatten(),
-            limit: origin_content
-                .query
-                .get("limit")
-                .map(|v| v.parse().ok())
-                .flatten(),
-            comment_service: origin_content.extensions.resolve(),
-            entity_comment_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/comments/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/comments/response_content_failure.rs
@@ -1,48 +1,9 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum CommentsResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(incorrect_id = "post")]
     IncorrectIdFormat { reason: String },
-}
-
-impl ApiResponseContentBase for CommentsResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            CommentsResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            CommentsResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-        }
-    }
-}
-
-impl ApiResponseContentFailure for CommentsResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            CommentsResponseContentFailure::DatabaseError { reason: _ } => {
-                "COMMENTS_DATABASE_ERROR"
-            }
-            CommentsResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                "COMMENTS_INCORRECT_ID_FORMAT"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            CommentsResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            CommentsResponseContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for post ID: {}", reason)
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/comments/response_content_success.rs
+++ b/blog-server-api/src/endpoints/comments/response_content_success.rs
@@ -1,36 +1,14 @@
 use blog_generic::entities::CommentsContainer;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(found, description = "comments list returned")]
 pub struct CommentsResponseContentSuccess {
     pub(super) container: CommentsContainer,
 }
 
-impl Into<CommentsResponseContentSuccess> for CommentsContainer {
-    fn into(self) -> CommentsResponseContentSuccess {
-        CommentsResponseContentSuccess { container: self }
-    }
-}
-
-impl ApiResponseContentBase for CommentsResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for CommentsResponseContentSuccess {
-    type Data = CommentsContainer;
-
-    fn identifier(&self) -> &'static str {
-        "COMMENTS_OK"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("comments list returned".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
+impl From<CommentsContainer> for CommentsResponseContentSuccess {
+    fn from(value: CommentsContainer) -> Self {
+        CommentsResponseContentSuccess { container: value }
     }
 }

--- a/blog-server-api/src/endpoints/create_comment/handler.rs
+++ b/blog-server-api/src/endpoints/create_comment/handler.rs
@@ -1,23 +1,19 @@
+use blog_server_services::traits::author_service::Author;
+
 use super::request_content::CreateCommentRequestContent;
 use super::response_content_failure::CreateCommentContentFailure;
 use super::response_content_failure::CreateCommentContentFailure::*;
 use super::response_content_success::CreateCommentContentSuccess;
 
 pub async fn http_handler(
-    (CreateCommentRequestContent {
-        new_comment_data,
-        comment_service,
-        auth_author_future,
-    },): (CreateCommentRequestContent,),
+    (
+        author,
+        CreateCommentRequestContent {
+            new_comment_data,
+            comment_service,
+        },
+    ): (Author, CreateCommentRequestContent),
 ) -> Result<CreateCommentContentSuccess, CreateCommentContentFailure> {
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.blocked == 1 {
-        return Err(CreatingForbidden);
-    }
-
     let base_comment = new_comment_data.map_err(|e| ValidationError {
         reason: e.to_string(),
     })?;
@@ -25,13 +21,15 @@ pub async fn http_handler(
     if base_comment.content.is_empty() {
         return Err(ValidationError {
             reason: "comment should not be empty".to_owned(),
-        });
+        }
+        .into());
     }
 
     if base_comment.content.chars().count() > 500 {
         return Err(ValidationError {
             reason: "comment should not less then 500 symbols".to_owned(),
-        });
+        }
+        .into());
     }
 
     let _ = comment_service

--- a/blog-server-api/src/endpoints/create_comment/request_content.rs
+++ b/blog-server-api/src/endpoints/create_comment/request_content.rs
@@ -1,33 +1,13 @@
-use crate::{extensions::Resolve, utils::auth};
 use blog_generic::entities::CommonComment;
-use blog_server_services::traits::{
-    author_service::{Author, AuthorService},
-    comment_service::CommentService,
-};
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::{dyn_fn::DFuture, dyn_result::DResult};
+use blog_server_api_macros::ApiRequest;
+use blog_server_services::traits::comment_service::CommentService;
+use screw_components::dyn_result::DResult;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct CreateCommentRequestContent {
+    #[request(data)]
     pub(super) new_comment_data: DResult<CommonComment>,
+    #[request(extension)]
     pub(super) comment_service: Arc<dyn CommentService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for CreateCommentRequestContent
-where
-    Extensions: Resolve<Arc<dyn CommentService>> + Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = CommonComment;
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            new_comment_data: origin_content.data_result,
-            comment_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/create_comment/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/create_comment/response_content_failure.rs
@@ -1,72 +1,15 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum CreateCommentContentFailure {
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(validation)]
     ValidationError { reason: String },
+    #[failure(status = INTERNAL_SERVER_ERROR, reason = "error while creating new comment")]
     InsertFailed,
-    Unauthorized { reason: String },
-    CreatingForbidden,
-}
-
-impl ApiResponseContentBase for CreateCommentContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            CreateCommentContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            CreateCommentContentFailure::ValidationError { reason: _ } => StatusCode::BAD_REQUEST,
-            CreateCommentContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
-            CreateCommentContentFailure::InsertFailed => StatusCode::INTERNAL_SERVER_ERROR,
-            CreateCommentContentFailure::CreatingForbidden => StatusCode::FORBIDDEN,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for CreateCommentContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            CreateCommentContentFailure::DatabaseError { reason: _ } => {
-                "CREATE_COMMENT_DATABASE_ERROR"
-            }
-            CreateCommentContentFailure::ValidationError { reason: _ } => {
-                "CREATE_COMMENT_VALIDATION_ERROR"
-            }
-            CreateCommentContentFailure::InsertFailed => {
-                "CREATE_COMMENT_COULD_NOT_FIND_CREATED_COMMENT"
-            }
-            CreateCommentContentFailure::Unauthorized { reason: _ } => {
-                "CREATE_COMMENT_UNAUTHORIZED"
-            }
-            CreateCommentContentFailure::CreatingForbidden => "CREATE_COMMENT_CREATING_FORBIDDEN",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            CreateCommentContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            CreateCommentContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            CreateCommentContentFailure::ValidationError { reason } => {
-                format!("validation error: {}", reason)
-            }
-            CreateCommentContentFailure::InsertFailed => {
-                String::from("error while creating new comment")
-            }
-            CreateCommentContentFailure::CreatingForbidden => {
-                String::from("insufficient rights to create comment")
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/create_comment/response_content_success.rs
+++ b/blog-server-api/src/endpoints/create_comment/response_content_success.rs
@@ -1,27 +1,5 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(created, description = "comment record created")]
 pub struct CreateCommentContentSuccess;
-
-impl ApiResponseContentBase for CreateCommentContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for CreateCommentContentSuccess {
-    type Data = ();
-
-    fn identifier(&self) -> &'static str {
-        "COMMENT_CREATED"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some(String::from("comment record created"))
-    }
-
-    fn data(&self) -> &Self::Data {
-        &()
-    }
-}

--- a/blog-server-api/src/endpoints/create_post/handler.rs
+++ b/blog-server-api/src/endpoints/create_post/handler.rs
@@ -1,5 +1,6 @@
 use blog_generic::entities::PublishType;
 use blog_generic::events::NewPostPublished;
+use blog_server_services::traits::author_service::Author;
 use validator::Validate;
 
 use super::request_content::CreatePostRequestContent;
@@ -8,22 +9,16 @@ use super::response_content_failure::CreatePostContentFailure::*;
 use super::response_content_success::CreatePostContentSuccess;
 
 pub async fn http_handler(
-    (CreatePostRequestContent {
-        new_post_data,
-        post_service,
-        entity_post_service,
-        auth_author_future,
-        new_post_service,
-    },): (CreatePostRequestContent,),
+    (
+        author,
+        CreatePostRequestContent {
+            new_post_data,
+            post_service,
+            entity_post_service,
+            new_post_service,
+        },
+    ): (Author, CreatePostRequestContent),
 ) -> Result<CreatePostContentSuccess, CreatePostContentFailure> {
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.blocked == 1 {
-        return Err(CreatingForbidden);
-    }
-
     let base_post = new_post_data.map_err(|e| ValidationError {
         reason: e.to_string(),
     })?;
@@ -31,13 +26,15 @@ pub async fn http_handler(
     if let Some(err) = base_post.validate().err() {
         return Err(ValidationError {
             reason: err.to_string(),
-        });
+        }
+        .into());
     }
 
     if author.base.editor == 0 && base_post.publish_type.is_published() {
         return Err(ValidationError {
             reason: "publishing not allowed for you".to_owned(),
-        });
+        }
+        .into());
     }
 
     let tag_titles: Vec<String> = base_post.tags.to_owned();

--- a/blog-server-api/src/endpoints/create_post/request_content.rs
+++ b/blog-server-api/src/endpoints/create_post/request_content.rs
@@ -1,42 +1,19 @@
-use crate::{extensions::Resolve, utils::auth};
 use blog_generic::{entities::CommonPost, events::NewPostPublished};
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::{
-    Publish,
-    author_service::{Author, AuthorService},
-    entity_post_service::EntityPostService,
-    post_service::PostService,
+    Publish, entity_post_service::EntityPostService, post_service::PostService,
 };
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::{dyn_fn::DFuture, dyn_result::DResult};
+use screw_components::dyn_result::DResult;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct CreatePostRequestContent {
+    #[request(data)]
     pub(super) new_post_data: DResult<CommonPost>,
+    #[request(extension)]
     pub(super) post_service: Arc<dyn PostService>,
+    #[request(extension)]
     pub(super) entity_post_service: Arc<dyn EntityPostService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
+    #[request(extension)]
     pub(super) new_post_service: Arc<dyn Publish<NewPostPublished>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for CreatePostRequestContent
-where
-    Extensions: Resolve<Arc<dyn PostService>>
-        + Resolve<Arc<dyn AuthorService>>
-        + Resolve<Arc<dyn EntityPostService>>
-        + Resolve<Arc<dyn Publish<NewPostPublished>>>,
-{
-    type Data = CommonPost;
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            new_post_data: origin_content.data_result,
-            post_service: origin_content.extensions.resolve(),
-            entity_post_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-            new_post_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/create_post/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/create_post/response_content_failure.rs
@@ -1,64 +1,15 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum CreatePostContentFailure {
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(validation)]
     ValidationError { reason: String },
+    #[failure(status = INTERNAL_SERVER_ERROR, reason = "error while creating new post")]
     InsertFailed,
-    Unauthorized { reason: String },
-    CreatingForbidden,
-}
-
-impl ApiResponseContentBase for CreatePostContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            CreatePostContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            CreatePostContentFailure::ValidationError { reason: _ } => StatusCode::BAD_REQUEST,
-            CreatePostContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
-            CreatePostContentFailure::InsertFailed => StatusCode::INTERNAL_SERVER_ERROR,
-            CreatePostContentFailure::CreatingForbidden => StatusCode::FORBIDDEN,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for CreatePostContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            CreatePostContentFailure::DatabaseError { reason: _ } => "CREATE_POST_DATABASE_ERROR",
-            CreatePostContentFailure::ValidationError { reason: _ } => {
-                "CREATE_POST_VALIDATION_ERROR"
-            }
-            CreatePostContentFailure::InsertFailed => "CREATE_POST_COULD_NOT_FIND_CREATED_POST",
-            CreatePostContentFailure::Unauthorized { reason: _ } => "CREATE_POST_UNAUTHORIZED",
-            CreatePostContentFailure::CreatingForbidden => "CREATE_POST_CREATING_FORBIDDEN",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            CreatePostContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            CreatePostContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            CreatePostContentFailure::ValidationError { reason } => {
-                format!("validation error: {}", reason)
-            }
-            CreatePostContentFailure::InsertFailed => String::from("error while creating new post"),
-            CreatePostContentFailure::CreatingForbidden => {
-                String::from("insufficient rights to create post")
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/create_post/response_content_success.rs
+++ b/blog-server-api/src/endpoints/create_post/response_content_success.rs
@@ -1,38 +1,16 @@
 use blog_generic::entities::{Post, PostContainer};
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(created, description = "post record created")]
 pub struct CreatePostContentSuccess {
     container: PostContainer,
 }
 
-impl Into<CreatePostContentSuccess> for Post {
-    fn into(self) -> CreatePostContentSuccess {
+impl From<Post> for CreatePostContentSuccess {
+    fn from(value: Post) -> Self {
         CreatePostContentSuccess {
-            container: PostContainer { post: self },
+            container: PostContainer { post: value },
         }
-    }
-}
-
-impl ApiResponseContentBase for CreatePostContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for CreatePostContentSuccess {
-    type Data = PostContainer;
-
-    fn identifier(&self) -> &'static str {
-        "POST_CREATED"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some(String::from("post record created"))
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
     }
 }

--- a/blog-server-api/src/endpoints/delete_comment/handler.rs
+++ b/blog-server-api/src/endpoints/delete_comment/handler.rs
@@ -1,26 +1,22 @@
+use blog_server_services::traits::author_service::Author;
+
 use super::request_content::DeleteCommentRequestContent;
 use super::response_content_failure::DeleteCommentResponseContentFailure;
 use super::response_content_failure::DeleteCommentResponseContentFailure::*;
 use super::response_content_success::DeleteCommentResponseContentSuccess;
 
 pub async fn http_handler(
-    (DeleteCommentRequestContent {
-        id,
-        comment_service,
-        auth_author_future,
-    },): (DeleteCommentRequestContent,),
+    (
+        author,
+        DeleteCommentRequestContent {
+            id,
+            comment_service,
+        },
+    ): (Author, DeleteCommentRequestContent),
 ) -> Result<DeleteCommentResponseContentSuccess, DeleteCommentResponseContentFailure> {
     let id = id.parse::<u64>().map_err(|e| IncorrectIdFormat {
         reason: e.to_string(),
     })?;
-
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.blocked == 1 {
-        return Err(EditingForbidden);
-    }
 
     let comment = comment_service
         .comment_by_id(&id)

--- a/blog-server-api/src/endpoints/delete_comment/request_content.rs
+++ b/blog-server-api/src/endpoints/delete_comment/request_content.rs
@@ -1,35 +1,11 @@
-use blog_server_services::traits::author_service::{Author, AuthorService};
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::comment_service::CommentService;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::dyn_fn::DFuture;
 use std::sync::Arc;
 
-use crate::{extensions::Resolve, utils::auth};
-
+#[derive(ApiRequest)]
 pub struct DeleteCommentRequestContent {
+    #[request(path = "id")]
     pub(super) id: String,
+    #[request(extension)]
     pub(super) comment_service: Arc<dyn CommentService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for DeleteCommentRequestContent
-where
-    Extensions: Resolve<Arc<dyn CommentService>> + Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            id: origin_content
-                .path
-                .get("id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            comment_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/delete_comment/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/delete_comment/response_content_failure.rs
@@ -1,76 +1,17 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum DeleteCommentResponseContentFailure {
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(not_found = "comment")]
     NotFound,
+    #[failure(incorrect_id = "comment")]
     IncorrectIdFormat { reason: String },
-    Unauthorized { reason: String },
+    #[failure(status = FORBIDDEN, reason = "insufficient rights to delete comment")]
     EditingForbidden,
-}
-
-impl ApiResponseContentBase for DeleteCommentResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            DeleteCommentResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            DeleteCommentResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
-            DeleteCommentResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-            DeleteCommentResponseContentFailure::Unauthorized { reason: _ } => {
-                StatusCode::UNAUTHORIZED
-            }
-            DeleteCommentResponseContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for DeleteCommentResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            DeleteCommentResponseContentFailure::DatabaseError { reason: _ } => {
-                "DELETE_COMMENT_DATABASE_ERROR"
-            }
-            DeleteCommentResponseContentFailure::NotFound => "DELETE_COMMENT_NOT_FOUND",
-            DeleteCommentResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                "DELETE_COMMENT_INCORRECT_ID_FORMAT"
-            }
-            DeleteCommentResponseContentFailure::Unauthorized { reason: _ } => {
-                "DELETE_COMMENT_UNAUTHORIZED"
-            }
-            DeleteCommentResponseContentFailure::EditingForbidden => {
-                "DELETE_COMMENT_DELETING_FORBIDDEN"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            DeleteCommentResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            DeleteCommentResponseContentFailure::NotFound => {
-                "comment record not found in database".to_string()
-            }
-            DeleteCommentResponseContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for comment ID: {}", reason)
-            }
-            DeleteCommentResponseContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            DeleteCommentResponseContentFailure::EditingForbidden => {
-                String::from("insufficient rights to delete comment")
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/delete_comment/response_content_success.rs
+++ b/blog-server-api/src/endpoints/delete_comment/response_content_success.rs
@@ -1,27 +1,5 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "comment record deleted")]
 pub struct DeleteCommentResponseContentSuccess;
-
-impl ApiResponseContentBase for DeleteCommentResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for DeleteCommentResponseContentSuccess {
-    type Data = ();
-
-    fn identifier(&self) -> &'static str {
-        "DELETE_COMMENT_SUCCESS"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("comment record deleted".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &()
-    }
-}

--- a/blog-server-api/src/endpoints/delete_post/handler.rs
+++ b/blog-server-api/src/endpoints/delete_post/handler.rs
@@ -1,27 +1,23 @@
+use blog_server_services::traits::author_service::Author;
+
 use super::request_content::DeletePostRequestContent;
 use super::response_content_failure::DeletePostResponseContentFailure;
 use super::response_content_failure::DeletePostResponseContentFailure::*;
 use super::response_content_success::DeletePostResponseContentSuccess;
 
 pub async fn http_handler(
-    (DeletePostRequestContent {
-        id,
-        post_service,
-        comment_service,
-        auth_author_future,
-    },): (DeletePostRequestContent,),
+    (
+        author,
+        DeletePostRequestContent {
+            id,
+            post_service,
+            comment_service,
+        },
+    ): (Author, DeletePostRequestContent),
 ) -> Result<DeletePostResponseContentSuccess, DeletePostResponseContentFailure> {
     let id = id.parse::<u64>().map_err(|e| IncorrectIdFormat {
         reason: e.to_string(),
     })?;
-
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.blocked == 1 {
-        return Err(EditingForbidden);
-    }
 
     let post = post_service
         .post_by_id(&id)

--- a/blog-server-api/src/endpoints/delete_post/request_content.rs
+++ b/blog-server-api/src/endpoints/delete_post/request_content.rs
@@ -1,40 +1,14 @@
-use blog_server_services::traits::author_service::{Author, AuthorService};
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::comment_service::CommentService;
 use blog_server_services::traits::post_service::PostService;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::dyn_fn::DFuture;
 use std::sync::Arc;
 
-use crate::{extensions::Resolve, utils::auth};
-
+#[derive(ApiRequest)]
 pub struct DeletePostRequestContent {
+    #[request(path = "id")]
     pub(super) id: String,
+    #[request(extension)]
     pub(super) post_service: Arc<dyn PostService>,
+    #[request(extension)]
     pub(super) comment_service: Arc<dyn CommentService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for DeletePostRequestContent
-where
-    Extensions: Resolve<Arc<dyn PostService>>
-        + Resolve<Arc<dyn AuthorService>>
-        + Resolve<Arc<dyn CommentService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            id: origin_content
-                .path
-                .get("id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            post_service: origin_content.extensions.resolve(),
-            comment_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/delete_post/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/delete_post/response_content_failure.rs
@@ -1,74 +1,17 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum DeletePostResponseContentFailure {
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(not_found = "post")]
     NotFound,
+    #[failure(incorrect_id = "post")]
     IncorrectIdFormat { reason: String },
-    Unauthorized { reason: String },
+    #[failure(status = FORBIDDEN, reason = "insufficient rights to delete post")]
     EditingForbidden,
-}
-
-impl ApiResponseContentBase for DeletePostResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            DeletePostResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            DeletePostResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
-            DeletePostResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-            DeletePostResponseContentFailure::Unauthorized { reason: _ } => {
-                StatusCode::UNAUTHORIZED
-            }
-            DeletePostResponseContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for DeletePostResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            DeletePostResponseContentFailure::DatabaseError { reason: _ } => {
-                "DELETE_POST_DATABASE_ERROR"
-            }
-            DeletePostResponseContentFailure::NotFound => "DELETE_POST_NOT_FOUND",
-            DeletePostResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                "DELETE_POST_INCORRECT_ID_FORMAT"
-            }
-            DeletePostResponseContentFailure::Unauthorized { reason: _ } => {
-                "DELETE_POST_UNAUTHORIZED"
-            }
-            DeletePostResponseContentFailure::EditingForbidden => "DELETE_POST_DELETING_FORBIDDEN",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            DeletePostResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            DeletePostResponseContentFailure::NotFound => {
-                "post record not found in database".to_string()
-            }
-            DeletePostResponseContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for post ID: {}", reason)
-            }
-            DeletePostResponseContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            DeletePostResponseContentFailure::EditingForbidden => {
-                String::from("insufficient rights to delete post")
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/delete_post/response_content_success.rs
+++ b/blog-server-api/src/endpoints/delete_post/response_content_success.rs
@@ -1,27 +1,5 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "post record deleted")]
 pub struct DeletePostResponseContentSuccess;
-
-impl ApiResponseContentBase for DeletePostResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for DeletePostResponseContentSuccess {
-    type Data = ();
-
-    fn identifier(&self) -> &'static str {
-        "DELETE_POST_SUCCESS"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("post record deleted".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &()
-    }
-}

--- a/blog-server-api/src/endpoints/login/request_content.rs
+++ b/blog-server-api/src/endpoints/login/request_content.rs
@@ -1,25 +1,13 @@
-use crate::extensions::Resolve;
 use blog_generic::entities::LoginQuestion;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::author_service::*;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use screw_components::dyn_result::DResult;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct LoginRequestContent {
+    #[request(data)]
     pub(super) login_question: DResult<LoginQuestion>,
+    #[request(extension)]
     pub(super) author_service: Arc<dyn AuthorService>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for LoginRequestContent
-where
-    Extensions: Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = LoginQuestion;
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            login_question: origin_content.data_result,
-            author_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/login/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/login/response_content_failure.rs
@@ -1,90 +1,25 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum LoginResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(params)]
     ParamsDecodeError { reason: String },
-    SlugEmpty,
-    NotFound,
-    PasswordVerificationError { reason: String },
-    WrongPassword,
+    #[failure(token)]
     TokenGeneratingError { reason: String },
+    #[failure(not_found = "author")]
+    NotFound,
+    #[failure(status = BAD_REQUEST, reason = "author slug is empty in params")]
+    SlugEmpty,
+    #[failure(
+        status = INTERNAL_SERVER_ERROR,
+        reason = "internal password verification error",
+        debug_reason = "password verification error: {reason}"
+    )]
+    PasswordVerificationError { reason: String },
+    #[failure(status = FORBIDDEN, reason = "wrong password passed to request")]
+    WrongPassword,
+    #[failure(status = FORBIDDEN, reason = "lots of login attempts")]
     Blocked,
-}
-
-impl ApiResponseContentBase for LoginResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            LoginResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            LoginResponseContentFailure::ParamsDecodeError { reason: _ } => StatusCode::BAD_REQUEST,
-            LoginResponseContentFailure::SlugEmpty => StatusCode::BAD_REQUEST,
-            LoginResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
-            LoginResponseContentFailure::PasswordVerificationError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            LoginResponseContentFailure::WrongPassword => StatusCode::FORBIDDEN,
-            LoginResponseContentFailure::TokenGeneratingError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            LoginResponseContentFailure::Blocked => StatusCode::FORBIDDEN,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for LoginResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            LoginResponseContentFailure::DatabaseError { reason: _ } => "LOGIN_DATABASE_ERROR",
-            LoginResponseContentFailure::ParamsDecodeError { reason: _ } => "LOGIN_PARAMS_ERROR",
-            LoginResponseContentFailure::SlugEmpty => "LOGIN_AUTHOR_SLUG_EMPTY",
-            LoginResponseContentFailure::NotFound => "LOGIN_AUTHOR_NOT_FOUND",
-            LoginResponseContentFailure::PasswordVerificationError { reason: _ } => {
-                "LOGIN_PASSWORD_VERIFICATION_ERROR"
-            }
-            LoginResponseContentFailure::WrongPassword => "LOGIN_WRONG_PASSWORD",
-            LoginResponseContentFailure::TokenGeneratingError { reason: _ } => {
-                "LOGIN_TOKEN_GENERATING_ERROR"
-            }
-            LoginResponseContentFailure::Blocked => "LOGIN_BLOCKED",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            LoginResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            LoginResponseContentFailure::ParamsDecodeError { reason } => {
-                format!("params error: {}", reason)
-            }
-            LoginResponseContentFailure::SlugEmpty => "author slug is empty in params".to_string(),
-            LoginResponseContentFailure::NotFound => {
-                "author record not found in database".to_string()
-            }
-            LoginResponseContentFailure::PasswordVerificationError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("password verification error: {}", reason)
-                } else {
-                    "internal password verification error".to_string()
-                }
-            }
-            LoginResponseContentFailure::WrongPassword => {
-                "wrong password passed to request".to_string()
-            }
-            LoginResponseContentFailure::TokenGeneratingError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("token generating error: {}", reason)
-                } else {
-                    "internal token generating error".to_string()
-                }
-            }
-            LoginResponseContentFailure::Blocked => "lots of login attempts".to_string(),
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/login/response_content_success.rs
+++ b/blog-server-api/src/endpoints/login/response_content_success.rs
@@ -1,38 +1,16 @@
 use blog_generic::entities::LoginAnswer;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "login success and token generated")]
 pub struct LoginResponseContentSuccess {
     login_answer: LoginAnswer,
 }
 
-impl Into<LoginResponseContentSuccess> for String {
-    fn into(self) -> LoginResponseContentSuccess {
+impl From<String> for LoginResponseContentSuccess {
+    fn from(value: String) -> Self {
         LoginResponseContentSuccess {
-            login_answer: LoginAnswer { token: self },
+            login_answer: LoginAnswer { token: value },
         }
-    }
-}
-
-impl ApiResponseContentBase for LoginResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for LoginResponseContentSuccess {
-    type Data = LoginAnswer;
-
-    fn identifier(&self) -> &'static str {
-        "LOGIN_SUCCESS"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("login success and token generated".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.login_answer
     }
 }

--- a/blog-server-api/src/endpoints/post/handler.rs
+++ b/blog-server-api/src/endpoints/post/handler.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
 use blog_generic::entities::PostContainer;
+use blog_server_services::traits::author_service::Author;
 use blog_server_services::traits::entity_post_service::EntityPostService;
 use blog_server_services::traits::post_service::PostService;
-
-use crate::utils::auth;
 
 use super::request_content::PostRequestContent;
 use super::response_content_failure::PostResponseContentFailure;
@@ -12,12 +11,14 @@ use super::response_content_failure::PostResponseContentFailure::*;
 use super::response_content_success::PostResponseContentSuccess;
 
 pub async fn http_handler(
-    (PostRequestContent {
-        id,
-        post_service,
-        entity_post_service,
-        auth_author_future,
-    },): (PostRequestContent,),
+    (
+        author,
+        PostRequestContent {
+            id,
+            post_service,
+            entity_post_service,
+        },
+    ): (Option<Author>, PostRequestContent),
 ) -> Result<PostResponseContentSuccess, PostResponseContentFailure> {
     let id = id.parse::<u64>().map_err(|e| IncorrectIdFormat {
         reason: e.to_string(),
@@ -32,13 +33,13 @@ pub async fn http_handler(
         .ok_or(NotFound)?;
 
     if !post.base.publish_type.is_published() {
-        let have_access = if let Some(author) = auth_author_future.await.ok() {
+        let have_access = if let Some(author) = author {
             post.base.author_id == author.id || author.base.editor == 1
         } else {
             false
         };
         if !have_access {
-            return Err(NotFound);
+            return Err(NotFound.into());
         }
     }
 
@@ -58,12 +59,14 @@ pub async fn direct_handler(
     post_service: Arc<dyn PostService>,
     entity_post_service: Arc<dyn EntityPostService>,
 ) -> Option<PostContainer> {
-    http_handler((PostRequestContent {
-        id,
-        post_service,
-        entity_post_service,
-        auth_author_future: Box::pin(std::future::ready(Err(auth::Error::TokenMissing))),
-    },))
+    http_handler((
+        None,
+        PostRequestContent {
+            id,
+            post_service,
+            entity_post_service,
+        },
+    ))
     .await
     .ok()
     .map(|s| s.container)

--- a/blog-server-api/src/endpoints/post/request_content.rs
+++ b/blog-server-api/src/endpoints/post/request_content.rs
@@ -1,41 +1,15 @@
-use crate::{extensions::Resolve, utils::auth};
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::{
-    author_service::{Author, AuthorService},
-    entity_post_service::EntityPostService,
-    post_service::PostService,
+    entity_post_service::EntityPostService, post_service::PostService,
 };
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::dyn_fn::DFuture;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct PostRequestContent {
+    #[request(path = "id")]
     pub(super) id: String,
+    #[request(extension)]
     pub(super) post_service: Arc<dyn PostService>,
+    #[request(extension)]
     pub(super) entity_post_service: Arc<dyn EntityPostService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for PostRequestContent
-where
-    Extensions: Resolve<Arc<dyn PostService>>
-        + Resolve<Arc<dyn EntityPostService>>
-        + Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            id: origin_content
-                .path
-                .get("id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            post_service: origin_content.extensions.resolve(),
-            entity_post_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/post/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/post/response_content_failure.rs
@@ -1,48 +1,11 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum PostResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(not_found = "post")]
     NotFound,
+    #[failure(incorrect_id = "post")]
     IncorrectIdFormat { reason: String },
-}
-
-impl ApiResponseContentBase for PostResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            PostResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            PostResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
-            PostResponseContentFailure::IncorrectIdFormat { reason: _ } => StatusCode::BAD_REQUEST,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for PostResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            PostResponseContentFailure::DatabaseError { reason: _ } => "POST_DATABASE_ERROR",
-            PostResponseContentFailure::NotFound => "POST_NOT_FOUND",
-            PostResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                "POST_INCORRECT_ID_FORMAT"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            PostResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            PostResponseContentFailure::NotFound => "post record not found in database".to_string(),
-            PostResponseContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for post ID: {}", reason)
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/post/response_content_success.rs
+++ b/blog-server-api/src/endpoints/post/response_content_success.rs
@@ -1,38 +1,16 @@
 use blog_generic::entities::{Post, PostContainer};
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(found, description = "post record found")]
 pub struct PostResponseContentSuccess {
     pub(super) container: PostContainer,
 }
 
-impl Into<PostResponseContentSuccess> for Post {
-    fn into(self) -> PostResponseContentSuccess {
+impl From<Post> for PostResponseContentSuccess {
+    fn from(value: Post) -> Self {
         PostResponseContentSuccess {
-            container: PostContainer { post: self },
+            container: PostContainer { post: value },
         }
-    }
-}
-
-impl ApiResponseContentBase for PostResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for PostResponseContentSuccess {
-    type Data = PostContainer;
-
-    fn identifier(&self) -> &'static str {
-        "POST_FOUND"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("post record found".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
     }
 }

--- a/blog-server-api/src/endpoints/post_recommendation/handler.rs
+++ b/blog-server-api/src/endpoints/post_recommendation/handler.rs
@@ -23,7 +23,7 @@ pub async fn http_handler(
         .map_err(|e| DatabaseError {
             reason: e.to_string(),
         })?
-        .ok_or(NotFound)?;
+        .ok_or(NotFound {})?;
 
     let post_entity = entity_post_service
         .posts_entities(vec![post])

--- a/blog-server-api/src/endpoints/post_recommendation/request_content.rs
+++ b/blog-server-api/src/endpoints/post_recommendation/request_content.rs
@@ -1,31 +1,15 @@
-use crate::extensions::Resolve;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::{
     entity_post_service::EntityPostService, post_service::PostService,
 };
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct PostRecommendationRequestContent {
+    #[request(path = "id")]
     pub(super) id: String,
+    #[request(extension)]
     pub(super) post_service: Arc<dyn PostService>,
+    #[request(extension)]
     pub(super) entity_post_service: Arc<dyn EntityPostService>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for PostRecommendationRequestContent
-where
-    Extensions: Resolve<Arc<dyn PostService>> + Resolve<Arc<dyn EntityPostService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            id: origin_content
-                .path
-                .get("id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            post_service: origin_content.extensions.resolve(),
-            entity_post_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/post_recommendation/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/post_recommendation/response_content_failure.rs
@@ -1,54 +1,11 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum PostRecommendationResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(not_found = "post recommendation")]
     NotFound,
+    #[failure(incorrect_id = "post")]
     IncorrectIdFormat { reason: String },
-}
-
-impl ApiResponseContentBase for PostRecommendationResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            PostRecommendationResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            PostRecommendationResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
-            PostRecommendationResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-        }
-    }
-}
-
-impl ApiResponseContentFailure for PostRecommendationResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            PostRecommendationResponseContentFailure::DatabaseError { reason: _ } => {
-                "POST_RECOMMENDATION_DATABASE_ERROR"
-            }
-            PostRecommendationResponseContentFailure::NotFound => "POST_RECOMMENDATION_NOT_FOUND",
-            PostRecommendationResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                "POST_RECOMMENDATION_INCORRECT_ID_FORMAT"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            PostRecommendationResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            PostRecommendationResponseContentFailure::NotFound => {
-                "post recommendation not found".to_string()
-            }
-            PostRecommendationResponseContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for post ID: {}", reason)
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/post_recommendation/response_content_success.rs
+++ b/blog-server-api/src/endpoints/post_recommendation/response_content_success.rs
@@ -1,38 +1,16 @@
 use blog_generic::entities::{Post, PostContainer};
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(found, description = "recommended post found")]
 pub struct PostRecommendationResponseContentSuccess {
     pub(super) container: PostContainer,
 }
 
-impl Into<PostRecommendationResponseContentSuccess> for Post {
-    fn into(self) -> PostRecommendationResponseContentSuccess {
+impl From<Post> for PostRecommendationResponseContentSuccess {
+    fn from(value: Post) -> Self {
         PostRecommendationResponseContentSuccess {
-            container: PostContainer { post: self },
+            container: PostContainer { post: value },
         }
-    }
-}
-
-impl ApiResponseContentBase for PostRecommendationResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for PostRecommendationResponseContentSuccess {
-    type Data = PostContainer;
-
-    fn identifier(&self) -> &'static str {
-        "POST_RECOMMENDATION_FOUND"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("recommended post found".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
     }
 }

--- a/blog-server-api/src/endpoints/post_update_recommended/handler.rs
+++ b/blog-server-api/src/endpoints/post_update_recommended/handler.rs
@@ -1,42 +1,32 @@
+use blog_server_services::traits::author_service::Author;
+
 use super::request_content::PostUpdateRecommendedRequestContent;
 use super::response_content_failure::PostUpdateRecommendedResponseContentFailure;
 use super::response_content_failure::PostUpdateRecommendedResponseContentFailure::*;
 use super::response_content_success::PostUpdateRecommendedResponseContentSuccess;
 
 pub async fn http_handler_true(
-    (request_content,): (PostUpdateRecommendedRequestContent,),
+    (_, request_content): (Author, PostUpdateRecommendedRequestContent),
 ) -> Result<PostUpdateRecommendedResponseContentSuccess, PostUpdateRecommendedResponseContentFailure>
 {
     http_handler(request_content, 1).await
 }
 
 pub async fn http_handler_false(
-    (request_content,): (PostUpdateRecommendedRequestContent,),
+    (_, request_content): (Author, PostUpdateRecommendedRequestContent),
 ) -> Result<PostUpdateRecommendedResponseContentSuccess, PostUpdateRecommendedResponseContentFailure>
 {
     http_handler(request_content, 0).await
 }
 
 async fn http_handler(
-    PostUpdateRecommendedRequestContent {
-        id,
-        post_service,
-        auth_author_future,
-    }: PostUpdateRecommendedRequestContent,
+    PostUpdateRecommendedRequestContent { id, post_service }: PostUpdateRecommendedRequestContent,
     recommended: u8,
 ) -> Result<PostUpdateRecommendedResponseContentSuccess, PostUpdateRecommendedResponseContentFailure>
 {
     let id = id.parse::<u64>().map_err(|e| IncorrectIdFormat {
         reason: e.to_string(),
     })?;
-
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.editor != 1 {
-        return Err(Forbidden);
-    }
 
     post_service
         .set_post_recommended_by_id(&id, &recommended)

--- a/blog-server-api/src/endpoints/post_update_recommended/request_content.rs
+++ b/blog-server-api/src/endpoints/post_update_recommended/request_content.rs
@@ -1,37 +1,11 @@
-use crate::extensions::Resolve;
-use crate::utils::auth;
-use blog_server_services::traits::{
-    author_service::{Author, AuthorService},
-    post_service::PostService,
-};
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::dyn_fn::DFuture;
+use blog_server_api_macros::ApiRequest;
+use blog_server_services::traits::post_service::PostService;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct PostUpdateRecommendedRequestContent {
+    #[request(path = "id")]
     pub(super) id: String,
+    #[request(extension)]
     pub(super) post_service: Arc<dyn PostService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for PostUpdateRecommendedRequestContent
-where
-    Extensions: Resolve<Arc<dyn PostService>> + Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            id: origin_content
-                .path
-                .get("id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            post_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/post_update_recommended/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/post_update_recommended/response_content_failure.rs
@@ -1,70 +1,13 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum PostUpdateRecommendedResponseContentFailure {
-    Unauthorized { reason: String },
-    Forbidden,
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(incorrect_id = "post")]
     IncorrectIdFormat { reason: String },
-}
-
-impl ApiResponseContentBase for PostUpdateRecommendedResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            PostUpdateRecommendedResponseContentFailure::Unauthorized { reason: _ } => {
-                StatusCode::UNAUTHORIZED
-            }
-            PostUpdateRecommendedResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
-            PostUpdateRecommendedResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            PostUpdateRecommendedResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-        }
-    }
-}
-
-impl ApiResponseContentFailure for PostUpdateRecommendedResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            PostUpdateRecommendedResponseContentFailure::Unauthorized { reason: _ } => {
-                "POST_UPDATE_RECOMMENDED_UNAUTHORIZED"
-            }
-            PostUpdateRecommendedResponseContentFailure::Forbidden => {
-                "POST_UPDATE_RECOMMENDED_FORBIDDEN"
-            }
-            PostUpdateRecommendedResponseContentFailure::DatabaseError { reason: _ } => {
-                "POST_UPDATE_RECOMMENDED_DATABASE_ERROR"
-            }
-            PostUpdateRecommendedResponseContentFailure::IncorrectIdFormat { reason: _ } => {
-                "POST_UPDATE_RECOMMENDED_INCORRECT_ID_FORMAT"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            PostUpdateRecommendedResponseContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            PostUpdateRecommendedResponseContentFailure::Forbidden => {
-                String::from("insufficient rights")
-            }
-            PostUpdateRecommendedResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            PostUpdateRecommendedResponseContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for post ID: {}", reason)
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/post_update_recommended/response_content_success.rs
+++ b/blog-server-api/src/endpoints/post_update_recommended/response_content_success.rs
@@ -1,27 +1,5 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "post recommended state changed")]
 pub struct PostUpdateRecommendedResponseContentSuccess;
-
-impl ApiResponseContentBase for PostUpdateRecommendedResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for PostUpdateRecommendedResponseContentSuccess {
-    type Data = ();
-
-    fn identifier(&self) -> &'static str {
-        "POST_UPDATE_RECOMMENDED_OK"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("post recommended state changed".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &()
-    }
-}

--- a/blog-server-api/src/endpoints/posts/handler.rs
+++ b/blog-server-api/src/endpoints/posts/handler.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
-use crate::utils::auth;
 use blog_generic::entities::{PostsContainer, PublishType, TotalOffsetLimitContainer};
 use blog_server_services::traits::author_service::Author;
 use blog_server_services::traits::entity_post_service::EntityPostService;
 use blog_server_services::traits::post_service::{PostService, PostsQuery, PostsQueryAnswer};
-use screw_components::dyn_fn::DFuture;
 
 use super::request_content::{PostsRequestContentFilter as Filter, *};
 use super::response_content_failure::PostsResponseContentFailure;
@@ -19,32 +17,26 @@ pub async fn http_handler(
 }
 
 pub async fn http_handler_unpublished(
-    (UnpublishedPostsRequestContent {
-        base: posts_request_content,
-        auth_author_future,
-    },): (UnpublishedPostsRequestContent,),
+    (author, posts_request_content): (Author, PostsRequestContent),
 ) -> Result<PostsResponseContentSuccess, PostsResponseContentFailure> {
     handler(
         posts_request_content,
         HandlerType::AuthRequired {
             inner_type: HandlerTypeAuthRequired::Unpublished,
-            auth_author_future,
+            author,
         },
     )
     .await
 }
 
 pub async fn http_handler_hidden(
-    (UnpublishedPostsRequestContent {
-        base: posts_request_content,
-        auth_author_future,
-    },): (UnpublishedPostsRequestContent,),
+    (author, posts_request_content): (Author, PostsRequestContent),
 ) -> Result<PostsResponseContentSuccess, PostsResponseContentFailure> {
     handler(
         posts_request_content,
         HandlerType::AuthRequired {
             inner_type: HandlerTypeAuthRequired::Hidden,
-            auth_author_future,
+            author,
         },
     )
     .await
@@ -59,7 +51,7 @@ enum HandlerType {
     Published,
     AuthRequired {
         inner_type: HandlerTypeAuthRequired,
-        auth_author_future: DFuture<Result<Author, auth::Error>>,
+        author: Author,
     },
 }
 
@@ -78,13 +70,7 @@ async fn handler(
 
     let publish_type = match handler_type {
         HandlerType::Published => PublishType::Published,
-        HandlerType::AuthRequired {
-            inner_type,
-            auth_author_future,
-        } => {
-            let author = auth_author_future.await.map_err(|e| Unauthorized {
-                reason: e.to_string(),
-            })?;
+        HandlerType::AuthRequired { inner_type, author } => {
             if !(filter.author_id == Some(author.id) || author.base.editor == 1) {
                 return Err(Forbidden);
             }
@@ -302,22 +288,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unauthorized_error_when_token_invalid() {
-        let post_service = Arc::new(MockPostService {
-            behavior: PostBehavior::Success(0),
-        });
-        let entity_post_service = Arc::new(MockEntityPostService {
-            behavior: EntityBehavior::Success(vec![]),
-        });
-        let request = UnpublishedPostsRequestContent {
-            base: empty_request(post_service, entity_post_service),
-            auth_author_future: Box::pin(async { Err(auth::Error::TokenMissing) }),
-        };
-        let result = http_handler_unpublished((request,)).await;
-        assert!(matches!(result, Err(Unauthorized { .. })));
-    }
-
-    #[tokio::test]
     async fn forbidden_when_author_mismatch() {
         let post_service = Arc::new(MockPostService {
             behavior: PostBehavior::Success(0),
@@ -325,22 +295,42 @@ mod tests {
         let entity_post_service = Arc::new(MockEntityPostService {
             behavior: EntityBehavior::Success(vec![]),
         });
-        let request = UnpublishedPostsRequestContent {
-            base: PostsRequestContent {
-                filter: Filter {
-                    search_query: None,
-                    author_id: Some(2),
-                    tag_id: None,
-                },
-                offset: None,
-                limit: None,
-                post_service,
-                entity_post_service,
+        let request = PostsRequestContent {
+            filter: Filter {
+                search_query: None,
+                author_id: Some(2),
+                tag_id: None,
             },
-            auth_author_future: Box::pin(async { Ok(sample_author(0, 1)) }),
+            offset: None,
+            limit: None,
+            post_service,
+            entity_post_service,
         };
-        let result = http_handler_unpublished((request,)).await;
+        let result = http_handler_unpublished((sample_author(0, 1), request)).await;
         assert!(matches!(result, Err(Forbidden)));
+    }
+
+    #[tokio::test]
+    async fn editor_may_read_other_authors_unpublished() {
+        let post_service = Arc::new(MockPostService {
+            behavior: PostBehavior::Success(0),
+        });
+        let entity_post_service = Arc::new(MockEntityPostService {
+            behavior: EntityBehavior::Success(vec![]),
+        });
+        let request = PostsRequestContent {
+            filter: Filter {
+                search_query: None,
+                author_id: Some(2),
+                tag_id: None,
+            },
+            offset: None,
+            limit: None,
+            post_service,
+            entity_post_service,
+        };
+        let result = http_handler_unpublished((sample_author(1, 1), request)).await;
+        assert!(matches!(result, Ok(_)));
     }
 
     #[tokio::test]

--- a/blog-server-api/src/endpoints/posts/request_content.rs
+++ b/blog-server-api/src/endpoints/posts/request_content.rs
@@ -1,11 +1,8 @@
-use crate::{extensions::Resolve, utils::auth};
+use crate::extensions::Resolve;
 use blog_server_services::traits::{
-    author_service::{Author, AuthorService},
-    entity_post_service::EntityPostService,
-    post_service::PostService,
+    entity_post_service::EntityPostService, post_service::PostService,
 };
 use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
-use screw_components::dyn_fn::DFuture;
 use std::sync::Arc;
 
 pub struct PostsRequestContentFilter {
@@ -58,31 +55,6 @@ where
                 .flatten(),
             post_service: origin_content.extensions.resolve(),
             entity_post_service: origin_content.extensions.resolve(),
-        }
-    }
-}
-
-pub struct UnpublishedPostsRequestContent {
-    pub(super) base: PostsRequestContent,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for UnpublishedPostsRequestContent
-where
-    Extensions: Resolve<Arc<dyn PostService>>
-        + Resolve<Arc<dyn EntityPostService>>
-        + Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        let auth_author_future = Box::pin(auth::author(
-            &origin_content.http_parts,
-            origin_content.extensions.resolve(),
-        ));
-        Self {
-            base: PostsRequestContent::create(origin_content),
-            auth_author_future,
         }
     }
 }

--- a/blog-server-api/src/endpoints/posts/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/posts/response_content_failure.rs
@@ -1,50 +1,13 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum PostsResponseContentFailure {
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
-    Unauthorized { reason: String },
+    #[failure(status = FORBIDDEN, reason = "insufficient rights")]
     Forbidden,
-}
-
-impl ApiResponseContentBase for PostsResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            PostsResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            PostsResponseContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
-            PostsResponseContentFailure::Forbidden => StatusCode::FORBIDDEN,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for PostsResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            PostsResponseContentFailure::DatabaseError { reason: _ } => "POSTS_DATABASE_ERROR",
-            PostsResponseContentFailure::Unauthorized { reason: _ } => "POSTS_UNAUTHORIZED",
-            PostsResponseContentFailure::Forbidden => "POSTS_FORBIDDEN",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            PostsResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            PostsResponseContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            PostsResponseContentFailure::Forbidden => String::from("insufficient rights"),
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/posts/response_content_success.rs
+++ b/blog-server-api/src/endpoints/posts/response_content_success.rs
@@ -1,36 +1,14 @@
 use blog_generic::entities::PostsContainer;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(found, description = "posts list returned")]
 pub struct PostsResponseContentSuccess {
     pub(super) container: PostsContainer,
 }
 
-impl Into<PostsResponseContentSuccess> for PostsContainer {
-    fn into(self) -> PostsResponseContentSuccess {
-        PostsResponseContentSuccess { container: self }
-    }
-}
-
-impl ApiResponseContentBase for PostsResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for PostsResponseContentSuccess {
-    type Data = PostsContainer;
-
-    fn identifier(&self) -> &'static str {
-        "POSTS_OK"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("posts list returned".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
+impl From<PostsContainer> for PostsResponseContentSuccess {
+    fn from(value: PostsContainer) -> Self {
+        PostsResponseContentSuccess { container: value }
     }
 }

--- a/blog-server-api/src/endpoints/tag/request_content.rs
+++ b/blog-server-api/src/endpoints/tag/request_content.rs
@@ -1,27 +1,11 @@
-use crate::extensions::Resolve;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::post_service::PostService;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct TagRequestContent {
+    #[request(path = "id")]
     pub(super) id: String,
+    #[request(extension)]
     pub(super) post_service: Arc<dyn PostService>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for TagRequestContent
-where
-    Extensions: Resolve<Arc<dyn PostService>>,
-{
-    type Data = ();
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            id: origin_content
-                .path
-                .get("id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            post_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/tag/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/tag/response_content_failure.rs
@@ -1,46 +1,11 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum TagResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(not_found = "tag")]
     NotFound,
+    #[failure(incorrect_id = "tag")]
     IncorrectIdFormat { reason: String },
-}
-
-impl ApiResponseContentBase for TagResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            TagResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            TagResponseContentFailure::NotFound => StatusCode::NOT_FOUND,
-            TagResponseContentFailure::IncorrectIdFormat { reason: _ } => StatusCode::BAD_REQUEST,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for TagResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            TagResponseContentFailure::DatabaseError { reason: _ } => "TAG_DATABASE_ERROR",
-            TagResponseContentFailure::NotFound => "TAG_NOT_FOUND",
-            TagResponseContentFailure::IncorrectIdFormat { reason: _ } => "TAG_INCORRECT_ID_FORMAT",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            TagResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            TagResponseContentFailure::NotFound => "tag record not found in database".to_string(),
-            TagResponseContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for tag ID: {}", reason)
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/tag/response_content_success.rs
+++ b/blog-server-api/src/endpoints/tag/response_content_success.rs
@@ -1,39 +1,17 @@
 use blog_generic::entities::TagContainer;
+use blog_server_api_macros::ApiSuccess;
 use blog_server_services::traits::post_service::Tag as ServiceTag;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(found, description = "tag record found")]
 pub struct TagResponseContentSuccess {
     pub(super) container: TagContainer,
 }
 
-impl Into<TagResponseContentSuccess> for ServiceTag {
-    fn into(self) -> TagResponseContentSuccess {
+impl From<ServiceTag> for TagResponseContentSuccess {
+    fn from(value: ServiceTag) -> Self {
         TagResponseContentSuccess {
-            container: TagContainer { tag: self.into() },
+            container: TagContainer { tag: value.into() },
         }
-    }
-}
-
-impl ApiResponseContentBase for TagResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for TagResponseContentSuccess {
-    type Data = TagContainer;
-
-    fn identifier(&self) -> &'static str {
-        "TAG_FOUND"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("tag record found".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
     }
 }

--- a/blog-server-api/src/endpoints/telegram_login/request_content.rs
+++ b/blog-server-api/src/endpoints/telegram_login/request_content.rs
@@ -1,25 +1,13 @@
-use crate::extensions::Resolve;
 use blog_generic::entities::LoginTelegramQuestion;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::social_service::SocialService;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use screw_components::dyn_result::DResult;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct LoginTelegramRequestContent {
+    #[request(data)]
     pub(super) login_telegram_question: DResult<LoginTelegramQuestion>,
+    #[request(extension)]
     pub(super) social_service: Arc<dyn SocialService>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for LoginTelegramRequestContent
-where
-    Extensions: Resolve<Arc<dyn SocialService>>,
-{
-    type Data = LoginTelegramQuestion;
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            login_telegram_question: origin_content.data_result,
-            social_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/telegram_login/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/telegram_login/response_content_failure.rs
@@ -1,76 +1,17 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum LoginTelegramResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(params)]
     ParamsDecodeError { reason: String },
+    #[failure(token)]
     TokenGeneratingError { reason: String },
+    #[failure(
+        status = BAD_REQUEST,
+        reason = "internal telegram vendor error",
+        debug_reason = "telegram vendor error: {reason}"
+    )]
     TelegramError { reason: String },
-}
-
-impl ApiResponseContentBase for LoginTelegramResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            LoginTelegramResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            LoginTelegramResponseContentFailure::ParamsDecodeError { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-            LoginTelegramResponseContentFailure::TokenGeneratingError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            LoginTelegramResponseContentFailure::TelegramError { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-        }
-    }
-}
-
-impl ApiResponseContentFailure for LoginTelegramResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            LoginTelegramResponseContentFailure::DatabaseError { reason: _ } => {
-                "LOGIN_TELEGRAM_DATABASE_ERROR"
-            }
-            LoginTelegramResponseContentFailure::ParamsDecodeError { reason: _ } => {
-                "LOGIN_TELEGRAM_PARAMS_ERROR"
-            }
-            LoginTelegramResponseContentFailure::TokenGeneratingError { reason: _ } => {
-                "LOGIN_TELEGRAM_TOKEN_GENERATING_ERROR"
-            }
-            LoginTelegramResponseContentFailure::TelegramError { reason: _ } => {
-                "LOGIN_TELEGRAM_VENDOR_ERROR"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            LoginTelegramResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            LoginTelegramResponseContentFailure::ParamsDecodeError { reason } => {
-                format!("params error: {}", reason)
-            }
-            LoginTelegramResponseContentFailure::TokenGeneratingError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("token generating error: {}", reason)
-                } else {
-                    "internal token generating error".to_string()
-                }
-            }
-            LoginTelegramResponseContentFailure::TelegramError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("telegram vendor error: {}", reason)
-                } else {
-                    "internal telegram vendor error".to_string()
-                }
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/telegram_login/response_content_success.rs
+++ b/blog-server-api/src/endpoints/telegram_login/response_content_success.rs
@@ -1,38 +1,16 @@
 use blog_generic::entities::LoginAnswer;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "login telegram success and token generated")]
 pub struct LoginTelegramResponseContentSuccess {
     login_answer: LoginAnswer,
 }
 
-impl Into<LoginTelegramResponseContentSuccess> for String {
-    fn into(self) -> LoginTelegramResponseContentSuccess {
+impl From<String> for LoginTelegramResponseContentSuccess {
+    fn from(value: String) -> Self {
         LoginTelegramResponseContentSuccess {
-            login_answer: LoginAnswer { token: self },
+            login_answer: LoginAnswer { token: value },
         }
-    }
-}
-
-impl ApiResponseContentBase for LoginTelegramResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for LoginTelegramResponseContentSuccess {
-    type Data = LoginAnswer;
-
-    fn identifier(&self) -> &'static str {
-        "LOGIN_TELEGRAM_SUCCESS"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("login telegram success and token generated".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.login_answer
     }
 }

--- a/blog-server-api/src/endpoints/update_minimal_author/handler.rs
+++ b/blog-server-api/src/endpoints/update_minimal_author/handler.rs
@@ -1,3 +1,4 @@
+use blog_server_services::traits::author_service::Author;
 use validator::Validate;
 
 use super::request_content::UpdateMinimalAuthorRequestContent;
@@ -6,20 +7,14 @@ use super::response_content_failure::UpdateMinimalAuthorContentFailure::*;
 use super::response_content_success::UpdateMinimalAuthorContentSuccess;
 
 pub async fn http_handler(
-    (UpdateMinimalAuthorRequestContent {
-        updated_minimal_author_data,
-        author_service,
-        auth_author_future,
-    },): (UpdateMinimalAuthorRequestContent,),
+    (
+        author,
+        UpdateMinimalAuthorRequestContent {
+            updated_minimal_author_data,
+            author_service,
+        },
+    ): (Author, UpdateMinimalAuthorRequestContent),
 ) -> Result<UpdateMinimalAuthorContentSuccess, UpdateMinimalAuthorContentFailure> {
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.blocked == 1 {
-        return Err(EditingForbidden);
-    }
-
     let base_minimal_author = updated_minimal_author_data.map_err(|e| ValidationError {
         reason: e.to_string(),
     })?;

--- a/blog-server-api/src/endpoints/update_minimal_author/request_content.rs
+++ b/blog-server-api/src/endpoints/update_minimal_author/request_content.rs
@@ -1,33 +1,13 @@
 use blog_generic::entities::CommonMinimalAuthor;
-use blog_server_services::traits::author_service::{Author, AuthorService};
-use screw_api::request::ApiRequestContent;
-use screw_components::{dyn_fn::DFuture, dyn_result::DResult};
+use blog_server_api_macros::ApiRequest;
+use blog_server_services::traits::author_service::AuthorService;
+use screw_components::dyn_result::DResult;
 use std::sync::Arc;
 
-use crate::{extensions::Resolve, utils::auth};
-
+#[derive(ApiRequest)]
 pub struct UpdateMinimalAuthorRequestContent {
+    #[request(data)]
     pub(super) updated_minimal_author_data: DResult<CommonMinimalAuthor>,
+    #[request(extension)]
     pub(super) author_service: Arc<dyn AuthorService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for UpdateMinimalAuthorRequestContent
-where
-    Extensions: Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = CommonMinimalAuthor;
-
-    fn create(
-        origin_content: screw_api::request::ApiRequestOriginContent<Self::Data, Extensions>,
-    ) -> Self {
-        Self {
-            updated_minimal_author_data: origin_content.data_result,
-            author_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/update_minimal_author/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/update_minimal_author/response_content_failure.rs
@@ -1,70 +1,13 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum UpdateMinimalAuthorContentFailure {
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(validation)]
     ValidationError { reason: String },
-    Unauthorized { reason: String },
-    EditingForbidden,
-}
-
-impl ApiResponseContentBase for UpdateMinimalAuthorContentFailure {
-    fn status_code(&self) -> hyper::StatusCode {
-        match self {
-            UpdateMinimalAuthorContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            UpdateMinimalAuthorContentFailure::ValidationError { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-            UpdateMinimalAuthorContentFailure::Unauthorized { reason: _ } => {
-                StatusCode::UNAUTHORIZED
-            }
-            UpdateMinimalAuthorContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for UpdateMinimalAuthorContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            UpdateMinimalAuthorContentFailure::DatabaseError { reason: _ } => {
-                "UPDATE_MINIMAL_AUTHOR_DATABASE_ERROR"
-            }
-            UpdateMinimalAuthorContentFailure::ValidationError { reason: _ } => {
-                "UPDATE_MINIMAL_AUTHOR_VALIDATION_ERROR"
-            }
-            UpdateMinimalAuthorContentFailure::Unauthorized { reason: _ } => {
-                "UPDATE_MINIMAL_AUTHOR_UNAUTHORIZED"
-            }
-            UpdateMinimalAuthorContentFailure::EditingForbidden => {
-                "UPDATE_MINIMAL_AUTHOR_EDITING_FORBIDDEN"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            UpdateMinimalAuthorContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            UpdateMinimalAuthorContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            UpdateMinimalAuthorContentFailure::ValidationError { reason } => {
-                format!("validation error: {}", reason)
-            }
-            UpdateMinimalAuthorContentFailure::EditingForbidden => {
-                String::from("insufficient rights to edit author")
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/update_minimal_author/response_content_success.rs
+++ b/blog-server-api/src/endpoints/update_minimal_author/response_content_success.rs
@@ -1,33 +1,11 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "minimal author record updated")]
 pub struct UpdateMinimalAuthorContentSuccess;
 
-impl Into<UpdateMinimalAuthorContentSuccess> for () {
-    fn into(self) -> UpdateMinimalAuthorContentSuccess {
+impl From<()> for UpdateMinimalAuthorContentSuccess {
+    fn from(_value: ()) -> Self {
         UpdateMinimalAuthorContentSuccess
-    }
-}
-
-impl ApiResponseContentBase for UpdateMinimalAuthorContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for UpdateMinimalAuthorContentSuccess {
-    type Data = ();
-
-    fn identifier(&self) -> &'static str {
-        "UPDATE_MINIMAL_AUTHOR_SUCCESS"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some(String::from("minimal author record updated"))
-    }
-
-    fn data(&self) -> &Self::Data {
-        &()
     }
 }

--- a/blog-server-api/src/endpoints/update_post/handler.rs
+++ b/blog-server-api/src/endpoints/update_post/handler.rs
@@ -1,5 +1,6 @@
 use blog_generic::entities::PublishType;
 use blog_generic::events::NewPostPublished;
+use blog_server_services::traits::author_service::Author;
 use validator::Validate;
 
 use super::request_content::UpdatePostRequestContent;
@@ -8,26 +9,20 @@ use super::response_content_failure::UpdatePostContentFailure::*;
 use super::response_content_success::UpdatePostContentSuccess;
 
 pub async fn http_handler(
-    (UpdatePostRequestContent {
-        id,
-        updated_post_data,
-        post_service,
-        entity_post_service,
-        auth_author_future,
-        new_post_service,
-    },): (UpdatePostRequestContent,),
+    (
+        author,
+        UpdatePostRequestContent {
+            id,
+            updated_post_data,
+            post_service,
+            entity_post_service,
+            new_post_service,
+        },
+    ): (Author, UpdatePostRequestContent),
 ) -> Result<UpdatePostContentSuccess, UpdatePostContentFailure> {
     let id = id.parse::<u64>().map_err(|e| IncorrectIdFormat {
         reason: e.to_string(),
     })?;
-
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.blocked == 1 {
-        return Err(EditingForbidden);
-    }
 
     let existing_post = post_service
         .post_by_id(&id)
@@ -35,13 +30,13 @@ pub async fn http_handler(
         .map_err(|e| DatabaseError {
             reason: e.to_string(),
         })?
-        .ok_or(PostNotFound)?;
+        .ok_or(NotFound)?;
 
     if !(existing_post.base.author_id == author.id || author.base.editor == 1) {
         return Err(if existing_post.base.publish_type.is_published() {
             EditingForbidden
         } else {
-            PostNotFound
+            NotFound.into()
         });
     }
 
@@ -56,13 +51,15 @@ pub async fn http_handler(
     if let Some(err) = base_post.validate().err() {
         return Err(ValidationError {
             reason: err.to_string(),
-        });
+        }
+        .into());
     }
 
     if author.base.editor == 0 && base_post.publish_type.is_published() {
         return Err(ValidationError {
             reason: "publishing not allowed for you".to_owned(),
-        });
+        }
+        .into());
     }
 
     let tag_titles: Vec<String> = base_post.tags.to_owned();
@@ -99,7 +96,7 @@ pub async fn http_handler(
         .map_err(|e| DatabaseError {
             reason: e.to_string(),
         })?
-        .ok_or(PostNotFound)?;
+        .ok_or(NotFound)?;
 
     let is_visible_published = updated_post.base.publish_type == PublishType::Published;
 

--- a/blog-server-api/src/endpoints/update_post/request_content.rs
+++ b/blog-server-api/src/endpoints/update_post/request_content.rs
@@ -1,51 +1,21 @@
 use blog_generic::{entities::CommonPost, events::NewPostPublished};
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::{
-    Publish,
-    author_service::{Author, AuthorService},
-    entity_post_service::EntityPostService,
-    post_service::PostService,
+    Publish, entity_post_service::EntityPostService, post_service::PostService,
 };
-use screw_api::request::ApiRequestContent;
-use screw_components::{dyn_fn::DFuture, dyn_result::DResult};
+use screw_components::dyn_result::DResult;
 use std::sync::Arc;
 
-use crate::{extensions::Resolve, utils::auth};
-
+#[derive(ApiRequest)]
 pub struct UpdatePostRequestContent {
+    #[request(path = "id")]
     pub(super) id: String,
+    #[request(data)]
     pub(super) updated_post_data: DResult<CommonPost>,
+    #[request(extension)]
     pub(super) post_service: Arc<dyn PostService>,
+    #[request(extension)]
     pub(super) entity_post_service: Arc<dyn EntityPostService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
+    #[request(extension)]
     pub(super) new_post_service: Arc<dyn Publish<NewPostPublished>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for UpdatePostRequestContent
-where
-    Extensions: Resolve<Arc<dyn PostService>>
-        + Resolve<Arc<dyn AuthorService>>
-        + Resolve<Arc<dyn EntityPostService>>
-        + Resolve<Arc<dyn Publish<NewPostPublished>>>,
-{
-    type Data = CommonPost;
-
-    fn create(
-        origin_content: screw_api::request::ApiRequestOriginContent<Self::Data, Extensions>,
-    ) -> Self {
-        Self {
-            id: origin_content
-                .path
-                .get("id")
-                .map(|n| n.to_owned())
-                .unwrap_or_default(),
-            updated_post_data: origin_content.data_result,
-            post_service: origin_content.extensions.resolve(),
-            entity_post_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-            new_post_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/update_post/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/update_post/response_content_failure.rs
@@ -1,74 +1,19 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum UpdatePostContentFailure {
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(validation)]
     ValidationError { reason: String },
-    Unauthorized { reason: String },
+    #[failure(not_found = "post")]
+    NotFound,
+    #[failure(incorrect_id = "post")]
     IncorrectIdFormat { reason: String },
-    PostNotFound,
+    #[failure(status = FORBIDDEN, reason = "insufficient rights to edit post")]
     EditingForbidden,
-}
-
-impl ApiResponseContentBase for UpdatePostContentFailure {
-    fn status_code(&self) -> hyper::StatusCode {
-        match self {
-            UpdatePostContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            UpdatePostContentFailure::PostNotFound => StatusCode::BAD_REQUEST,
-            UpdatePostContentFailure::ValidationError { reason: _ } => StatusCode::BAD_REQUEST,
-            UpdatePostContentFailure::Unauthorized { reason: _ } => StatusCode::UNAUTHORIZED,
-            UpdatePostContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
-            UpdatePostContentFailure::IncorrectIdFormat { reason: _ } => StatusCode::BAD_REQUEST,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for UpdatePostContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            UpdatePostContentFailure::DatabaseError { reason: _ } => "UPDATE_POST_DATABASE_ERROR",
-            UpdatePostContentFailure::ValidationError { reason: _ } => {
-                "UPDATE_POST_VALIDATION_ERROR"
-            }
-            UpdatePostContentFailure::PostNotFound => "UPDATE_POST_NOT_FOUND",
-            UpdatePostContentFailure::Unauthorized { reason: _ } => "UPDATE_POST_UNAUTHORIZED",
-            UpdatePostContentFailure::IncorrectIdFormat { reason: _ } => {
-                "UPDATE_POST_INCORRECT_ID_FORMAT"
-            }
-            UpdatePostContentFailure::EditingForbidden => "UPDATE_POST_EDITING_FORBIDDEN",
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            UpdatePostContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            UpdatePostContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            UpdatePostContentFailure::ValidationError { reason } => {
-                format!("validation error: {}", reason)
-            }
-            UpdatePostContentFailure::PostNotFound => {
-                String::from("post with specified ID not found")
-            }
-            UpdatePostContentFailure::IncorrectIdFormat { reason } => {
-                format!("incorrect value provided for post ID: {}", reason)
-            }
-            UpdatePostContentFailure::EditingForbidden => {
-                String::from("insufficient rights to edit post")
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/update_post/response_content_success.rs
+++ b/blog-server-api/src/endpoints/update_post/response_content_success.rs
@@ -1,38 +1,16 @@
 use blog_generic::entities::{Post, PostContainer};
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "post record updated")]
 pub struct UpdatePostContentSuccess {
     container: PostContainer,
 }
 
-impl Into<UpdatePostContentSuccess> for Post {
-    fn into(self) -> UpdatePostContentSuccess {
+impl From<Post> for UpdatePostContentSuccess {
+    fn from(value: Post) -> Self {
         UpdatePostContentSuccess {
-            container: PostContainer { post: self },
+            container: PostContainer { post: value },
         }
-    }
-}
-
-impl ApiResponseContentBase for UpdatePostContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for UpdatePostContentSuccess {
-    type Data = PostContainer;
-
-    fn identifier(&self) -> &'static str {
-        "UPDATE_POST_SUCCESS"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some(String::from("post record updated"))
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.container
     }
 }

--- a/blog-server-api/src/endpoints/update_secondary_author/handler.rs
+++ b/blog-server-api/src/endpoints/update_secondary_author/handler.rs
@@ -1,3 +1,4 @@
+use blog_server_services::traits::author_service::Author;
 use validator::Validate;
 
 use super::request_content::UpdateSecondaryAuthorRequestContent;
@@ -6,20 +7,14 @@ use super::response_content_failure::UpdateSecondaryAuthorContentFailure::*;
 use super::response_content_success::UpdateSecondaryAuthorContentSuccess;
 
 pub async fn http_handler(
-    (UpdateSecondaryAuthorRequestContent {
-        updated_secondary_author_data,
-        author_service,
-        auth_author_future,
-    },): (UpdateSecondaryAuthorRequestContent,),
+    (
+        author,
+        UpdateSecondaryAuthorRequestContent {
+            updated_secondary_author_data,
+            author_service,
+        },
+    ): (Author, UpdateSecondaryAuthorRequestContent),
 ) -> Result<UpdateSecondaryAuthorContentSuccess, UpdateSecondaryAuthorContentFailure> {
-    let author = auth_author_future.await.map_err(|e| Unauthorized {
-        reason: e.to_string(),
-    })?;
-
-    if author.base.blocked == 1 {
-        return Err(EditingForbidden);
-    }
-
     let base_secondary_author = updated_secondary_author_data.map_err(|e| ValidationError {
         reason: e.to_string(),
     })?;

--- a/blog-server-api/src/endpoints/update_secondary_author/request_content.rs
+++ b/blog-server-api/src/endpoints/update_secondary_author/request_content.rs
@@ -1,33 +1,13 @@
 use blog_generic::entities::CommonSecondaryAuthor;
-use blog_server_services::traits::author_service::{Author, AuthorService};
-use screw_api::request::ApiRequestContent;
-use screw_components::{dyn_fn::DFuture, dyn_result::DResult};
+use blog_server_api_macros::ApiRequest;
+use blog_server_services::traits::author_service::AuthorService;
+use screw_components::dyn_result::DResult;
 use std::sync::Arc;
 
-use crate::{extensions::Resolve, utils::auth};
-
+#[derive(ApiRequest)]
 pub struct UpdateSecondaryAuthorRequestContent {
+    #[request(data)]
     pub(super) updated_secondary_author_data: DResult<CommonSecondaryAuthor>,
+    #[request(extension)]
     pub(super) author_service: Arc<dyn AuthorService>,
-    pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for UpdateSecondaryAuthorRequestContent
-where
-    Extensions: Resolve<Arc<dyn AuthorService>>,
-{
-    type Data = CommonSecondaryAuthor;
-
-    fn create(
-        origin_content: screw_api::request::ApiRequestOriginContent<Self::Data, Extensions>,
-    ) -> Self {
-        Self {
-            updated_secondary_author_data: origin_content.data_result,
-            author_service: origin_content.extensions.resolve(),
-            auth_author_future: Box::pin(auth::author(
-                &origin_content.http_parts,
-                origin_content.extensions.resolve(),
-            )),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/update_secondary_author/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/update_secondary_author/response_content_failure.rs
@@ -1,70 +1,13 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+use crate::utils::auth_middleware::AuthRejection;
+
+#[derive(ApiFailure)]
 pub enum UpdateSecondaryAuthorContentFailure {
+    #[failure(auth)]
+    Auth(AuthRejection),
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(validation)]
     ValidationError { reason: String },
-    Unauthorized { reason: String },
-    EditingForbidden,
-}
-
-impl ApiResponseContentBase for UpdateSecondaryAuthorContentFailure {
-    fn status_code(&self) -> hyper::StatusCode {
-        match self {
-            UpdateSecondaryAuthorContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            UpdateSecondaryAuthorContentFailure::ValidationError { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-            UpdateSecondaryAuthorContentFailure::Unauthorized { reason: _ } => {
-                StatusCode::UNAUTHORIZED
-            }
-            UpdateSecondaryAuthorContentFailure::EditingForbidden => StatusCode::FORBIDDEN,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for UpdateSecondaryAuthorContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            UpdateSecondaryAuthorContentFailure::DatabaseError { reason: _ } => {
-                "UPDATE_SECONDARY_AUTHOR_DATABASE_ERROR"
-            }
-            UpdateSecondaryAuthorContentFailure::ValidationError { reason: _ } => {
-                "UPDATE_SECONDARY_AUTHOR_VALIDATION_ERROR"
-            }
-            UpdateSecondaryAuthorContentFailure::Unauthorized { reason: _ } => {
-                "UPDATE_SECONDARY_AUTHOR_UNAUTHORIZED"
-            }
-            UpdateSecondaryAuthorContentFailure::EditingForbidden => {
-                "UPDATE_SECONDARY_AUTHOR_EDITING_FORBIDDEN"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            UpdateSecondaryAuthorContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            UpdateSecondaryAuthorContentFailure::Unauthorized { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("unauthorized error: {}", reason)
-                } else {
-                    "unauthorized error".to_string()
-                }
-            }
-            UpdateSecondaryAuthorContentFailure::ValidationError { reason } => {
-                format!("validation error: {}", reason)
-            }
-            UpdateSecondaryAuthorContentFailure::EditingForbidden => {
-                String::from("insufficient rights to edit author")
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/update_secondary_author/response_content_success.rs
+++ b/blog-server-api/src/endpoints/update_secondary_author/response_content_success.rs
@@ -1,33 +1,11 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "secondary author record updated")]
 pub struct UpdateSecondaryAuthorContentSuccess;
 
-impl Into<UpdateSecondaryAuthorContentSuccess> for () {
-    fn into(self) -> UpdateSecondaryAuthorContentSuccess {
+impl From<()> for UpdateSecondaryAuthorContentSuccess {
+    fn from(_value: ()) -> Self {
         UpdateSecondaryAuthorContentSuccess
-    }
-}
-
-impl ApiResponseContentBase for UpdateSecondaryAuthorContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for UpdateSecondaryAuthorContentSuccess {
-    type Data = ();
-
-    fn identifier(&self) -> &'static str {
-        "UPDATE_SECONDARY_AUTHOR_SUCCESS"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some(String::from("secondary author record updated"))
-    }
-
-    fn data(&self) -> &Self::Data {
-        &()
     }
 }

--- a/blog-server-api/src/endpoints/yandex_login/request_content.rs
+++ b/blog-server-api/src/endpoints/yandex_login/request_content.rs
@@ -1,25 +1,13 @@
-use crate::extensions::Resolve;
 use blog_generic::entities::LoginYandexQuestion;
+use blog_server_api_macros::ApiRequest;
 use blog_server_services::traits::social_service::SocialService;
-use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use screw_components::dyn_result::DResult;
 use std::sync::Arc;
 
+#[derive(ApiRequest)]
 pub struct LoginYandexRequestContent {
+    #[request(data)]
     pub(super) login_yandex_question: DResult<LoginYandexQuestion>,
+    #[request(extension)]
     pub(super) social_service: Arc<dyn SocialService>,
-}
-
-impl<Extensions> ApiRequestContent<Extensions> for LoginYandexRequestContent
-where
-    Extensions: Resolve<Arc<dyn SocialService>>,
-{
-    type Data = LoginYandexQuestion;
-
-    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
-        Self {
-            login_yandex_question: origin_content.data_result,
-            social_service: origin_content.extensions.resolve(),
-        }
-    }
 }

--- a/blog-server-api/src/endpoints/yandex_login/response_content_failure.rs
+++ b/blog-server-api/src/endpoints/yandex_login/response_content_failure.rs
@@ -1,74 +1,17 @@
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentFailure};
+use blog_server_api_macros::ApiFailure;
 
+#[derive(ApiFailure)]
 pub enum LoginYandexResponseContentFailure {
+    #[failure(database)]
     DatabaseError { reason: String },
+    #[failure(params)]
     ParamsDecodeError { reason: String },
+    #[failure(token)]
     TokenGeneratingError { reason: String },
+    #[failure(
+        status = BAD_REQUEST,
+        reason = "internal yandex vendor error",
+        debug_reason = "yandex vendor error: {reason}"
+    )]
     YandexError { reason: String },
-}
-
-impl ApiResponseContentBase for LoginYandexResponseContentFailure {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            LoginYandexResponseContentFailure::DatabaseError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            LoginYandexResponseContentFailure::ParamsDecodeError { reason: _ } => {
-                StatusCode::BAD_REQUEST
-            }
-            LoginYandexResponseContentFailure::TokenGeneratingError { reason: _ } => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            LoginYandexResponseContentFailure::YandexError { reason: _ } => StatusCode::BAD_REQUEST,
-        }
-    }
-}
-
-impl ApiResponseContentFailure for LoginYandexResponseContentFailure {
-    fn identifier(&self) -> &'static str {
-        match self {
-            LoginYandexResponseContentFailure::DatabaseError { reason: _ } => {
-                "LOGIN_YANDEX_DATABASE_ERROR"
-            }
-            LoginYandexResponseContentFailure::ParamsDecodeError { reason: _ } => {
-                "LOGIN_YANDEX_PARAMS_ERROR"
-            }
-            LoginYandexResponseContentFailure::TokenGeneratingError { reason: _ } => {
-                "LOGIN_YANDEX_TOKEN_GENERATING_ERROR"
-            }
-            LoginYandexResponseContentFailure::YandexError { reason: _ } => {
-                "LOGIN_YANDEX_VENDOR_ERROR"
-            }
-        }
-    }
-
-    fn reason(&self) -> Option<String> {
-        Some(match self {
-            LoginYandexResponseContentFailure::DatabaseError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("database error: {}", reason)
-                } else {
-                    "internal database error".to_string()
-                }
-            }
-            LoginYandexResponseContentFailure::ParamsDecodeError { reason } => {
-                format!("params error: {}", reason)
-            }
-            LoginYandexResponseContentFailure::TokenGeneratingError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("token generating error: {}", reason)
-                } else {
-                    "internal token generating error".to_string()
-                }
-            }
-            LoginYandexResponseContentFailure::YandexError { reason } => {
-                if cfg!(debug_assertions) {
-                    format!("yandex vendor error: {}", reason)
-                } else {
-                    "internal yandex vendor error".to_string()
-                }
-            }
-        })
-    }
 }

--- a/blog-server-api/src/endpoints/yandex_login/response_content_success.rs
+++ b/blog-server-api/src/endpoints/yandex_login/response_content_success.rs
@@ -1,38 +1,16 @@
 use blog_generic::entities::LoginAnswer;
-use hyper::StatusCode;
-use screw_api::response::{ApiResponseContentBase, ApiResponseContentSuccess};
+use blog_server_api_macros::ApiSuccess;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ApiSuccess)]
+#[success(ok, description = "login yandex success and token generated")]
 pub struct LoginYandexResponseContentSuccess {
     login_answer: LoginAnswer,
 }
 
-impl Into<LoginYandexResponseContentSuccess> for String {
-    fn into(self) -> LoginYandexResponseContentSuccess {
+impl From<String> for LoginYandexResponseContentSuccess {
+    fn from(value: String) -> Self {
         LoginYandexResponseContentSuccess {
-            login_answer: LoginAnswer { token: self },
+            login_answer: LoginAnswer { token: value },
         }
-    }
-}
-
-impl ApiResponseContentBase for LoginYandexResponseContentSuccess {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::OK
-    }
-}
-
-impl ApiResponseContentSuccess for LoginYandexResponseContentSuccess {
-    type Data = LoginAnswer;
-
-    fn identifier(&self) -> &'static str {
-        "LOGIN_YANDEX_SUCCESS"
-    }
-
-    fn description(&self) -> Option<String> {
-        Some("login yandex success and token generated".to_string())
-    }
-
-    fn data(&self) -> &Self::Data {
-        &self.login_answer
     }
 }

--- a/blog-server-api/src/router.rs
+++ b/blog-server-api/src/router.rs
@@ -1,5 +1,6 @@
 use super::endpoints::*;
 use super::extensions::*;
+use super::utils::auth_middleware::{AuthApiMiddleware, AuthPolicy, OptionalAuthApiMiddleware};
 use screw_api::json::*;
 use screw_api::request::*;
 use screw_api::response::*;
@@ -85,48 +86,62 @@ pub fn make_router<Extensions: ExtensionsProviderType>()
                 r.scoped("/author", |r| {
                     r.route(
                         route::first::Route::with_method(&hyper::Method::GET)
-                            .and_path("/me")
-                            .and_handler(author_me::http_handler),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::GET)
                             .and_path("/slug/{slug:[^/]*}")
                             .and_handler(author::http_handler),
                     )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::GET)
-                            .and_path("/id/{id:[^/]*}/block")
-                            .and_handler(author_block::http_handler_block),
+                    .middleware(
+                        AuthApiMiddleware::with_policy(AuthPolicy::Authenticated),
+                        |r| {
+                            r.route(
+                                route::first::Route::with_method(&hyper::Method::GET)
+                                    .and_path("/me")
+                                    .and_handler(author_me::http_handler),
+                            )
+                            .route(
+                                route::first::Route::with_method(&hyper::Method::PATCH)
+                                    .and_path("/id/{id:[^/]*}/subscribe")
+                                    .and_handler(author_subscribe::http_handler_subscribe),
+                            )
+                            .route(
+                                route::first::Route::with_method(&hyper::Method::PATCH)
+                                    .and_path("/id/{id:[^/]*}/unsubscribe")
+                                    .and_handler(author_subscribe::http_handler_unsubscribe),
+                            )
+                        },
                     )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::GET)
-                            .and_path("/id/{id:[^/]*}/unblock")
-                            .and_handler(author_block::http_handler_unblock),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::PATCH)
-                            .and_path("/id/{id:[^/]*}/subscribe")
-                            .and_handler(author_subscribe::http_handler_subscribe),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::PATCH)
-                            .and_path("/id/{id:[^/]*}/unsubscribe")
-                            .and_handler(author_subscribe::http_handler_unsubscribe),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::PATCH)
-                            .and_path("/reset_override_social_data")
-                            .and_handler(author_override_social_data::http_handler_disabled),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::PATCH)
-                            .and_path("/minimal")
-                            .and_handler(update_minimal_author::http_handler),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::PATCH)
-                            .and_path("/secondary")
-                            .and_handler(update_secondary_author::http_handler),
+                    .middleware(AuthApiMiddleware::with_policy(AuthPolicy::Editor), |r| {
+                        r.route(
+                            route::first::Route::with_method(&hyper::Method::GET)
+                                .and_path("/id/{id:[^/]*}/block")
+                                .and_handler(author_block::http_handler_block),
+                        )
+                        .route(
+                            route::first::Route::with_method(&hyper::Method::GET)
+                                .and_path("/id/{id:[^/]*}/unblock")
+                                .and_handler(author_block::http_handler_unblock),
+                        )
+                    })
+                    .middleware(
+                        AuthApiMiddleware::with_policy(AuthPolicy::NotBlocked),
+                        |r| {
+                            r.route(
+                                route::first::Route::with_method(&hyper::Method::PATCH)
+                                    .and_path("/reset_override_social_data")
+                                    .and_handler(
+                                        author_override_social_data::http_handler_disabled,
+                                    ),
+                            )
+                            .route(
+                                route::first::Route::with_method(&hyper::Method::PATCH)
+                                    .and_path("/minimal")
+                                    .and_handler(update_minimal_author::http_handler),
+                            )
+                            .route(
+                                route::first::Route::with_method(&hyper::Method::PATCH)
+                                    .and_path("/secondary")
+                                    .and_handler(update_secondary_author::http_handler),
+                            )
+                        },
                     )
                 })
                 .scoped("/authors", |r| {
@@ -142,57 +157,74 @@ pub fn make_router<Extensions: ExtensionsProviderType>()
                     )
                 })
                 .scoped("/post", |r| {
-                    r.route(
-                        route::first::Route::with_method(&hyper::Method::GET)
-                            .and_path("/{id:[^/]*}")
-                            .and_handler(post::http_handler),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::PATCH)
-                            .and_path("/{id:[^/]*}")
-                            .and_handler(update_post::http_handler),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::DELETE)
-                            .and_path("/{id:[^/]*}")
-                            .and_handler(delete_post::http_handler),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::POST)
-                            .and_path("")
-                            .and_handler(create_post::http_handler),
-                    )
+                    r.middleware(OptionalAuthApiMiddleware, |r| {
+                        r.route(
+                            route::first::Route::with_method(&hyper::Method::GET)
+                                .and_path("/{id:[^/]*}")
+                                .and_handler(post::http_handler),
+                        )
+                    })
                     .route(
                         route::first::Route::with_method(&hyper::Method::GET)
                             .and_path("/{id:[^/]*}/recommendation")
                             .and_handler(post_recommendation::http_handler),
                     )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::PATCH)
-                            .and_path("/{id:[^/]*}/recommended/true")
-                            .and_handler(post_update_recommended::http_handler_true),
+                    .middleware(
+                        AuthApiMiddleware::with_policy(AuthPolicy::NotBlocked),
+                        |r| {
+                            r.route(
+                                route::first::Route::with_method(&hyper::Method::PATCH)
+                                    .and_path("/{id:[^/]*}")
+                                    .and_handler(update_post::http_handler),
+                            )
+                            .route(
+                                route::first::Route::with_method(&hyper::Method::DELETE)
+                                    .and_path("/{id:[^/]*}")
+                                    .and_handler(delete_post::http_handler),
+                            )
+                            .route(
+                                route::first::Route::with_method(&hyper::Method::POST)
+                                    .and_path("")
+                                    .and_handler(create_post::http_handler),
+                            )
+                        },
                     )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::PATCH)
-                            .and_path("/{id:[^/]*}/recommended/false")
-                            .and_handler(post_update_recommended::http_handler_false),
+                    .middleware(
+                        AuthApiMiddleware::with_policy(AuthPolicy::Editor),
+                        |r| {
+                            r.route(
+                                route::first::Route::with_method(&hyper::Method::PATCH)
+                                    .and_path("/{id:[^/]*}/recommended/true")
+                                    .and_handler(post_update_recommended::http_handler_true),
+                            )
+                            .route(
+                                route::first::Route::with_method(&hyper::Method::PATCH)
+                                    .and_path("/{id:[^/]*}/recommended/false")
+                                    .and_handler(post_update_recommended::http_handler_false),
+                            )
+                        },
                     )
                 })
                 .scoped("/posts", |r| {
-                    r.scoped("/unpublished", |r| {
-                        r.route(
-                            route::first::Route::with_method(&hyper::Method::GET)
-                                .and_path("")
-                                .and_handler(posts::http_handler_unpublished),
-                        )
-                    })
-                    .scoped("/hidden", |r| {
-                        r.route(
-                            route::first::Route::with_method(&hyper::Method::GET)
-                                .and_path("")
-                                .and_handler(posts::http_handler_hidden),
-                        )
-                    })
+                    r.middleware(
+                        AuthApiMiddleware::with_policy(AuthPolicy::Authenticated),
+                        |r| {
+                            r.scoped("/unpublished", |r| {
+                                r.route(
+                                    route::first::Route::with_method(&hyper::Method::GET)
+                                        .and_path("")
+                                        .and_handler(posts::http_handler_unpublished),
+                                )
+                            })
+                            .scoped("/hidden", |r| {
+                                r.route(
+                                    route::first::Route::with_method(&hyper::Method::GET)
+                                        .and_path("")
+                                        .and_handler(posts::http_handler_hidden),
+                                )
+                            })
+                        },
+                    )
                     .route(
                         route::first::Route::with_method(&hyper::Method::GET)
                             .and_path("")
@@ -210,15 +242,20 @@ pub fn make_router<Extensions: ExtensionsProviderType>()
                         .and_handler(comments::http_handler),
                 )
                 .scoped("/comment", |r| {
-                    r.route(
-                        route::first::Route::with_method(&hyper::Method::DELETE)
-                            .and_path("/{id:[^/]*}")
-                            .and_handler(delete_comment::http_handler),
-                    )
-                    .route(
-                        route::first::Route::with_method(&hyper::Method::POST)
-                            .and_path("")
-                            .and_handler(create_comment::http_handler),
+                    r.middleware(
+                        AuthApiMiddleware::with_policy(AuthPolicy::NotBlocked),
+                        |r| {
+                            r.route(
+                                route::first::Route::with_method(&hyper::Method::DELETE)
+                                    .and_path("/{id:[^/]*}")
+                                    .and_handler(delete_comment::http_handler),
+                            )
+                            .route(
+                                route::first::Route::with_method(&hyper::Method::POST)
+                                    .and_path("")
+                                    .and_handler(create_comment::http_handler),
+                            )
+                        },
                     )
                 })
                 .route(
@@ -259,4 +296,46 @@ pub fn make_router<Extensions: ExtensionsProviderType>()
                 .and_handler(robots_handler),
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blog_generic::events::{NewPostPublished, SubscriptionStateChanged};
+    use blog_server_services::traits::Publish;
+    use blog_server_services::traits::author_service::AuthorService;
+    use blog_server_services::traits::comment_service::CommentService;
+    use blog_server_services::traits::entity_comment_service::EntityCommentService;
+    use blog_server_services::traits::entity_post_service::EntityPostService;
+    use blog_server_services::traits::post_service::PostService;
+    use blog_server_services::traits::social_service::SocialService;
+    use std::sync::Arc;
+
+    struct StubExtensions;
+
+    macro_rules! stub_resolve {
+        ($service:ty) => {
+            impl Resolve<Arc<$service>> for StubExtensions {
+                fn resolve(&self) -> Arc<$service> {
+                    unimplemented!()
+                }
+            }
+        };
+    }
+
+    stub_resolve!(dyn AuthorService);
+    stub_resolve!(dyn PostService);
+    stub_resolve!(dyn CommentService);
+    stub_resolve!(dyn EntityCommentService);
+    stub_resolve!(dyn EntityPostService);
+    stub_resolve!(dyn SocialService);
+    stub_resolve!(dyn Publish<NewPostPublished>);
+    stub_resolve!(dyn Publish<SubscriptionStateChanged>);
+
+    impl ExtensionsProviderType for StubExtensions {}
+
+    #[test]
+    fn router_builds_without_route_conflicts() {
+        let _ = make_router::<StubExtensions>();
+    }
 }

--- a/blog-server-api/src/utils/auth_middleware.rs
+++ b/blog-server-api/src/utils/auth_middleware.rs
@@ -1,0 +1,288 @@
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use hyper::StatusCode;
+use screw_api::request::{ApiRequest, ApiRequestContent, ApiRequestOriginContent};
+use screw_api::response::{
+    ApiResponse, ApiResponseContentBase, ApiResponseContentFailure, ApiResponseContentSuccess,
+};
+use screw_components::dyn_fn::{DFnOnce, DFuture};
+use screw_core::routing::middleware::Middleware;
+
+use blog_server_services::traits::author_service::{Author, AuthorService};
+
+use crate::extensions::Resolve;
+use crate::utils::auth;
+
+#[derive(Clone, Copy, Debug)]
+pub enum AuthPolicy {
+    Authenticated,
+    NotBlocked,
+    Editor,
+}
+
+impl AuthPolicy {
+    fn check(&self, author: &Author) -> Result<(), AuthRejection> {
+        match self {
+            AuthPolicy::Authenticated => Ok(()),
+            AuthPolicy::NotBlocked => {
+                if author.base.blocked == 1 {
+                    Err(AuthRejection::Blocked)
+                } else {
+                    Ok(())
+                }
+            }
+            AuthPolicy::Editor => {
+                if author.base.editor == 0 {
+                    Err(AuthRejection::NotEditor)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+pub enum AuthRejection {
+    Unauthorized(auth::Error),
+    Blocked,
+    NotEditor,
+}
+
+impl ApiResponseContentBase for AuthRejection {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            AuthRejection::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+            AuthRejection::Blocked => StatusCode::FORBIDDEN,
+            AuthRejection::NotEditor => StatusCode::FORBIDDEN,
+        }
+    }
+}
+
+impl ApiResponseContentFailure for AuthRejection {
+    fn identifier(&self) -> &'static str {
+        match self {
+            AuthRejection::Unauthorized(_) => "UNAUTHORIZED",
+            AuthRejection::Blocked => "AUTHOR_BLOCKED",
+            AuthRejection::NotEditor => "EDITOR_RIGHTS_REQUIRED",
+        }
+    }
+
+    fn reason(&self) -> Option<String> {
+        Some(match self {
+            AuthRejection::Unauthorized(e) => {
+                if cfg!(debug_assertions) {
+                    format!("unauthorized error: {}", e)
+                } else {
+                    "unauthorized error".to_string()
+                }
+            }
+            AuthRejection::Blocked => "author is blocked".to_string(),
+            AuthRejection::NotEditor => "insufficient rights".to_string(),
+        })
+    }
+}
+
+pub struct AuthApiRequestContent<Content> {
+    auth_author_future: DFuture<Result<Author, auth::Error>>,
+    inner: Content,
+}
+
+impl<Content, Extensions> ApiRequestContent<Extensions> for AuthApiRequestContent<Content>
+where
+    Content: ApiRequestContent<Extensions>,
+    Extensions: Resolve<Arc<dyn AuthorService>>,
+{
+    type Data = Content::Data;
+
+    fn create(origin_content: ApiRequestOriginContent<Self::Data, Extensions>) -> Self {
+        let auth_author_future: DFuture<Result<Author, auth::Error>> = Box::pin(auth::author(
+            &origin_content.http_parts,
+            origin_content.extensions.resolve(),
+        ));
+        Self {
+            auth_author_future,
+            inner: Content::create(origin_content),
+        }
+    }
+}
+
+pub struct AuthorizedApiRequest<Content, Extensions> {
+    pub author: Author,
+    pub content: Content,
+    _p_e: PhantomData<Extensions>,
+}
+
+impl<Content, Extensions> From<AuthorizedApiRequest<Content, Extensions>> for (Author, Content) {
+    fn from(value: AuthorizedApiRequest<Content, Extensions>) -> Self {
+        (value.author, value.content)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct AuthApiMiddleware {
+    pub policy: AuthPolicy,
+}
+
+impl AuthApiMiddleware {
+    pub fn with_policy(policy: AuthPolicy) -> Self {
+        Self { policy }
+    }
+}
+
+impl<Content, Extensions, Success, Failure>
+    Middleware<AuthorizedApiRequest<Content, Extensions>, ApiResponse<Success, Failure>>
+    for AuthApiMiddleware
+where
+    Content: ApiRequestContent<Extensions> + Send + 'static,
+    <Content as ApiRequestContent<Extensions>>::Data: Sync + Send + 'static,
+    Extensions: Resolve<Arc<dyn AuthorService>> + Sync + Send + 'static,
+    Success: ApiResponseContentSuccess + Send + 'static,
+    Failure: ApiResponseContentFailure + From<AuthRejection> + Send + 'static,
+{
+    type Request = ApiRequest<AuthApiRequestContent<Content>, Extensions>;
+    type Response = ApiResponse<Success, Failure>;
+
+    async fn respond(
+        &self,
+        request: Self::Request,
+        next: DFnOnce<AuthorizedApiRequest<Content, Extensions>, ApiResponse<Success, Failure>>,
+    ) -> Self::Response {
+        let AuthApiRequestContent {
+            auth_author_future,
+            inner,
+        } = request.content;
+
+        let author = match auth_author_future.await {
+            Ok(author) => author,
+            Err(e) => return ApiResponse::failure(AuthRejection::Unauthorized(e).into()),
+        };
+
+        if let Err(rejection) = self.policy.check(&author) {
+            return ApiResponse::failure(rejection.into());
+        }
+
+        next(AuthorizedApiRequest {
+            author,
+            content: inner,
+            _p_e: PhantomData,
+        })
+        .await
+    }
+}
+
+pub struct MaybeAuthorizedApiRequest<Content, Extensions> {
+    pub author: Option<Author>,
+    pub content: Content,
+    _p_e: PhantomData<Extensions>,
+}
+
+impl<Content, Extensions> From<MaybeAuthorizedApiRequest<Content, Extensions>>
+    for (Option<Author>, Content)
+{
+    fn from(value: MaybeAuthorizedApiRequest<Content, Extensions>) -> Self {
+        (value.author, value.content)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct OptionalAuthApiMiddleware;
+
+impl<Content, Extensions, Success, Failure>
+    Middleware<MaybeAuthorizedApiRequest<Content, Extensions>, ApiResponse<Success, Failure>>
+    for OptionalAuthApiMiddleware
+where
+    Content: ApiRequestContent<Extensions> + Send + 'static,
+    <Content as ApiRequestContent<Extensions>>::Data: Sync + Send + 'static,
+    Extensions: Resolve<Arc<dyn AuthorService>> + Sync + Send + 'static,
+    Success: ApiResponseContentSuccess + Send + 'static,
+    Failure: ApiResponseContentFailure + Send + 'static,
+{
+    type Request = ApiRequest<AuthApiRequestContent<Content>, Extensions>;
+    type Response = ApiResponse<Success, Failure>;
+
+    async fn respond(
+        &self,
+        request: Self::Request,
+        next: DFnOnce<
+            MaybeAuthorizedApiRequest<Content, Extensions>,
+            ApiResponse<Success, Failure>,
+        >,
+    ) -> Self::Response {
+        let AuthApiRequestContent {
+            auth_author_future,
+            inner,
+        } = request.content;
+
+        next(MaybeAuthorizedApiRequest {
+            author: auth_author_future.await.ok(),
+            content: inner,
+            _p_e: PhantomData,
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blog_server_services::traits::author_service::BaseAuthor;
+
+    fn author(editor: u8, blocked: u8) -> Author {
+        Author {
+            id: 1,
+            base: BaseAuthor {
+                slug: "slug".to_string(),
+                first_name: None,
+                middle_name: None,
+                last_name: None,
+                mobile: None,
+                email: None,
+                password_hash: None,
+                registered_at: 0,
+                status: None,
+                image_url: None,
+                editor,
+                blocked,
+                yandex_id: None,
+                telegram_id: None,
+                notification_subscribed: None,
+                override_social_data: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn authenticated_policy_accepts_blocked_author() {
+        assert!(AuthPolicy::Authenticated.check(&author(0, 1)).is_ok());
+    }
+
+    #[test]
+    fn not_blocked_policy_rejects_blocked_author() {
+        let rejection = AuthPolicy::NotBlocked.check(&author(1, 1)).unwrap_err();
+        assert_eq!(rejection.status_code(), StatusCode::FORBIDDEN);
+        assert_eq!(rejection.identifier(), "AUTHOR_BLOCKED");
+    }
+
+    #[test]
+    fn not_blocked_policy_accepts_plain_author() {
+        assert!(AuthPolicy::NotBlocked.check(&author(0, 0)).is_ok());
+    }
+
+    #[test]
+    fn editor_policy_rejects_non_editor() {
+        let rejection = AuthPolicy::Editor.check(&author(0, 0)).unwrap_err();
+        assert_eq!(rejection.status_code(), StatusCode::FORBIDDEN);
+        assert_eq!(rejection.identifier(), "EDITOR_RIGHTS_REQUIRED");
+    }
+
+    #[test]
+    fn editor_policy_accepts_editor() {
+        assert!(AuthPolicy::Editor.check(&author(1, 0)).is_ok());
+    }
+
+    #[test]
+    fn editor_policy_ignores_blocked_flag() {
+        assert!(AuthPolicy::Editor.check(&author(1, 1)).is_ok());
+    }
+}

--- a/blog-server-api/src/utils/mod.rs
+++ b/blog-server-api/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod auth;
+pub mod auth_middleware;
 pub mod jwt;
 pub mod password;


### PR DESCRIPTION
Auth used to be resolved per endpoint: every request content built an auth_author_future and every handler awaited it and re-checked the author's flags. That now happens once, in AuthApiMiddleware, which resolves the Token header and applies one of three policies before the handler runs. Handlers take (Author, RequestContent), so a signature states what has already been checked. GET /api/post/{id} reads fine anonymously and richer when signed in, so it uses
OptionalAuthApiMiddleware and takes (Option<Author>, RequestContent).

The three screw traits are now derived by a new blog-server-api-macros crate, one derive each:

- ApiFailure, on the per-endpoint failure enum. Identifiers come from variant names and so cannot drift from them; shorthands supply the status and wording shared across endpoints.
- ApiSuccess, on the success struct. Data comes from the struct itself and the kind decides the identifier.
- ApiRequest, on the request content. The Extensions: Resolve<...>
  bound is generated from the fields, so it can no longer disagree with them.

Identifiers lose their per-endpoint prefixes: AUTHOR_BLOCK_DATABASE_ERROR and the twenty other spellings of the same thing all become DATABASE_ERROR, and successes answer FOUND, CREATED or OK. Both clients only ever display reason ?? identifier, so nothing reads the old strings.

Two deliberate behaviour changes: PATCH /api/post/{id} answers 404 rather than 400 when the post is missing, which is what every other not-found already did, and the post recommendation not-found message now follows the shared wording.

chatgpt and posts keep hand-written request contents, since one builds a session key out of several headers and the other nests a filter struct.