### PR TITLE
Add agent discovery: Link headers, API catalog, OpenAPI, markdown neg…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "no-referrer-when-downgrade" always;
 
-    location ~* ^(?!/(?:sitemap\.xml|robots\.txt|index\.html)$).+\.[a-z0-9]+$ {
+    location ~* ^(?!/(?:sitemap\.xml|robots\.txt|openapi\.json|index\.html)$).+\.[a-z0-9]+$ {
         limit_req zone=static burst=15 nodelay;
         limit_req_status 429;
         
@@ -166,7 +166,7 @@ COPY <<'EOF' /etc/nginx/conf.d/gzip.conf
 gzip_vary on;
 gzip_proxied any;
 gzip_comp_level 6;
-gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/wasm image/svg+xml;
+gzip_types text/plain text/markdown text/css application/json application/linkset+json application/vnd.oai.openapi+json application/javascript text/xml application/xml application/xml+rss text/javascript application/wasm image/svg+xml;
 EOF
 
 COPY <<'EOF' /app/start.sh

--- a/blog-server-api/src/endpoints/api_catalog_handler.rs
+++ b/blog-server-api/src/endpoints/api_catalog_handler.rs
@@ -1,0 +1,63 @@
+use screw_core::request::*;
+use screw_core::response::*;
+use screw_core::routing::*;
+
+use super::openapi_handler::{OPENAPI_MEDIA_TYPE, OPENAPI_PATH};
+
+pub const API_CATALOG_PATH: &str = "/.well-known/api-catalog";
+pub const API_CATALOG_MEDIA_TYPE: &str = "application/linkset+json";
+
+static API_CATALOG: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+    let site_url = &*crate::SITE_URL;
+    let linkset = serde_json::json!({
+        "linkset": [
+            {
+                "anchor": format!("{site_url}/api"),
+                "service-desc": [
+                    {
+                        "href": format!("{site_url}{OPENAPI_PATH}"),
+                        "type": OPENAPI_MEDIA_TYPE,
+                    },
+                ],
+                "describedby": [
+                    {
+                        "href": format!("{site_url}{OPENAPI_PATH}"),
+                        "type": OPENAPI_MEDIA_TYPE,
+                    },
+                ],
+            },
+        ],
+    });
+    serde_json::to_string(&linkset).expect("failed to serialize api catalog")
+});
+
+pub async fn api_catalog_handler<Extensions>(
+    _: router::RoutedRequest<Request<Extensions>>,
+) -> Response {
+    Response {
+        http: hyper::Response::builder()
+            .header("Content-Type", API_CATALOG_MEDIA_TYPE)
+            .header("Cache-Control", "public, max-age=3600")
+            .body(screw_core::body::full(API_CATALOG.as_str()))
+            .unwrap(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_anchors_the_api_and_points_at_the_description() {
+        unsafe { std::env::set_var("SITE_URL", "https://example.com") };
+        let catalog: serde_json::Value = serde_json::from_str(&API_CATALOG).unwrap();
+        let entry = &catalog["linkset"][0];
+
+        assert_eq!(entry["anchor"], "https://example.com/api");
+        assert_eq!(
+            entry["service-desc"][0]["href"],
+            "https://example.com/openapi.json"
+        );
+        assert_eq!(entry["service-desc"][0]["type"], OPENAPI_MEDIA_TYPE);
+    }
+}

--- a/blog-server-api/src/endpoints/client_handler.rs
+++ b/blog-server-api/src/endpoints/client_handler.rs
@@ -1,5 +1,6 @@
 use crate::endpoints::*;
 use crate::extensions::Resolve;
+use crate::utils::accept::prefers_markdown;
 use blog_server_services::traits::author_service::*;
 use blog_server_services::traits::entity_post_service::*;
 use blog_server_services::traits::post_service::*;
@@ -10,6 +11,17 @@ use screw_core::routing::*;
 
 use blog_generic::*;
 use blog_ui::*;
+
+use super::api_catalog_handler::{API_CATALOG_MEDIA_TYPE, API_CATALOG_PATH};
+use super::markdown_handler::{MARKDOWN_CONTENT_TYPE, markdown_page};
+use super::openapi_handler::{OPENAPI_MEDIA_TYPE, OPENAPI_PATH};
+
+static DISCOVERY_LINK_HEADER: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+    format!(
+        "<{API_CATALOG_PATH}>; rel=\"api-catalog\"; type=\"{API_CATALOG_MEDIA_TYPE}\", \
+         <{OPENAPI_PATH}>; rel=\"service-desc\"; type=\"{OPENAPI_MEDIA_TYPE}\""
+    )
+});
 
 static INDEX_HTML: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
     std::fs::read_to_string("dist/index.html")
@@ -89,6 +101,20 @@ pub async fn client_handler<
 >(
     request: router::RoutedRequest<Request<Extensions>>,
 ) -> Response {
+    if prefers_markdown(request.origin.http.headers()) {
+        if let Some((status, markdown)) = markdown_page(&request).await {
+            return Response {
+                http: hyper::Response::builder()
+                    .status(status)
+                    .header("Content-Type", MARKDOWN_CONTENT_TYPE)
+                    .header("Vary", "Accept")
+                    .header("Link", DISCOVERY_LINK_HEADER.as_str())
+                    .body(screw_core::body::full(markdown))
+                    .unwrap(),
+            };
+        }
+    }
+
     let (before, after) = INDEX_HTML.split_once(APP_TAG_PREFIX).unwrap();
 
     let (status, app_content) = resolve_page::<_, DefaultPageProcessor>(&request).await;
@@ -107,6 +133,8 @@ pub async fn client_handler<
         http: hyper::Response::builder()
             .status(status)
             .header("Content-Type", "text/html")
+            .header("Vary", "Accept")
+            .header("Link", DISCOVERY_LINK_HEADER.as_str())
             .body(screw_core::body::full(page))
             .unwrap(),
     }

--- a/blog-server-api/src/endpoints/markdown_handler.rs
+++ b/blog-server-api/src/endpoints/markdown_handler.rs
@@ -1,0 +1,351 @@
+use std::fmt::Write;
+use std::sync::Arc;
+
+use blog_generic::entities::*;
+use blog_generic::{DefaultPageProcessor, PageProcessor};
+use blog_server_services::traits::author_service::AuthorService;
+use blog_server_services::traits::entity_post_service::EntityPostService;
+use blog_server_services::traits::post_service::PostService;
+use blog_server_services::utils::html;
+use blog_ui::Route;
+
+use crate::endpoints::*;
+use crate::extensions::Resolve;
+
+use screw_core::request::*;
+use screw_core::routing::*;
+
+pub const MARKDOWN_CONTENT_TYPE: &str = "text/markdown; charset=utf-8";
+
+pub async fn markdown_page<Extensions>(
+    request: &router::RoutedRequest<Request<Extensions>>,
+) -> Option<(hyper::StatusCode, String)>
+where
+    Extensions: Resolve<Arc<dyn AuthorService>>
+        + Resolve<Arc<dyn PostService>>
+        + Resolve<Arc<dyn EntityPostService>>,
+{
+    let page = request
+        .query
+        .get("page")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let page_processor: DefaultPageProcessor = PageProcessor::create_for_page(&page);
+    let ext = &request.origin.extensions;
+
+    match Route::recognize_path(request.path.as_str())? {
+        Route::Post { slug, id } => {
+            let container = post::direct_handler(id.to_string(), ext.resolve(), ext.resolve())
+                .await
+                .filter(|c| c.post.id == id && c.post.slug == slug)?;
+            Some((hyper::StatusCode::OK, post_markdown(&container.post)))
+        }
+        Route::Posts => {
+            let container = posts::direct_handler(
+                page_processor.offset(),
+                page_processor.limit(),
+                ext.resolve(),
+                ext.resolve(),
+            )
+            .await?;
+            let status = page_status(!container.posts.is_empty());
+            Some((status, posts_markdown(&container)))
+        }
+        Route::Author { slug } => {
+            let container = author::direct_handler(slug, ext.resolve()).await?;
+            Some((hyper::StatusCode::OK, author_markdown(&container.author)))
+        }
+        Route::Authors => {
+            let container = authors::direct_handler(
+                page_processor.offset(),
+                page_processor.limit(),
+                ext.resolve(),
+            )
+            .await?;
+            let status = page_status(!container.authors.is_empty());
+            Some((status, authors_markdown(&container)))
+        }
+        _ => None,
+    }
+}
+
+fn page_status(found: bool) -> hyper::StatusCode {
+    if found {
+        hyper::StatusCode::OK
+    } else {
+        hyper::StatusCode::NOT_FOUND
+    }
+}
+
+fn post_markdown(post: &Post) -> String {
+    let mut out = String::new();
+    let mut front = FrontMatter::new();
+    front.text("type", "post");
+    front.text("title", &post.title);
+    front.text("url", &post_url(post));
+    front.text("author", &author_name(&post.author));
+    front.text("authorUrl", &author_url(&post.author));
+    front.text("published", &rfc3339(post.created_at));
+    if !post.tags.is_empty() {
+        front.list("tags", post.tags.iter().map(|t| t.title.as_str()));
+    }
+    front.write_to(&mut out);
+
+    let _ = writeln!(out, "# {}\n", post.title);
+    let _ = writeln!(out, "> {}\n", post.summary.replace('\n', " "));
+    if let Some(content) = post.content.as_deref() {
+        let _ = writeln!(out, "{}", html::to_markdown(content));
+    }
+    out
+}
+
+fn posts_markdown(container: &PostsContainer) -> String {
+    let mut out = String::new();
+    let mut front = FrontMatter::new();
+    front.text("type", "posts");
+    front.text("url", &format!("{site_url}/", site_url = &*crate::SITE_URL));
+    front.number("total", container.base.total);
+    front.number("offset", container.base.offset);
+    front.number("limit", container.base.limit);
+    front.write_to(&mut out);
+
+    for post in &container.posts {
+        let _ = writeln!(out, "## [{}]({})\n", post.title, post_url(post));
+        let _ = writeln!(out, "{}\n", post.summary.replace('\n', " "));
+        let mut facts = vec![
+            rfc3339(post.created_at),
+            format!(
+                "[{}]({})",
+                author_name(&post.author),
+                author_url(&post.author)
+            ),
+        ];
+        if !post.tags.is_empty() {
+            facts.push(post.joined_tags_string(", "));
+        }
+        let _ = writeln!(out, "{}\n", facts.join(" · "));
+    }
+    out
+}
+
+fn author_markdown(author: &Author) -> String {
+    let mut out = String::new();
+    let mut front = FrontMatter::new();
+    front.text("type", "author");
+    front.text("name", &author_name(author));
+    front.text("url", &author_url(author));
+    front.text("registered", &rfc3339(author.registered_at));
+    front.write_to(&mut out);
+
+    let _ = writeln!(out, "# {}\n", author_name(author));
+    if let Some(status) = author.status.as_deref().filter(|s| !s.is_empty()) {
+        let _ = writeln!(out, "{status}\n");
+    }
+    out
+}
+
+fn authors_markdown(container: &AuthorsContainer) -> String {
+    let mut out = String::new();
+    let mut front = FrontMatter::new();
+    front.text("type", "authors");
+    front.text(
+        "url",
+        &format!("{site_url}/authors", site_url = &*crate::SITE_URL),
+    );
+    front.number("total", container.base.total);
+    front.number("offset", container.base.offset);
+    front.number("limit", container.base.limit);
+    front.write_to(&mut out);
+
+    for author in &container.authors {
+        let _ = writeln!(
+            out,
+            "## [{}]({})\n",
+            author_name(author),
+            author_url(author)
+        );
+        if let Some(status) = author.status.as_deref().filter(|s| !s.is_empty()) {
+            let _ = writeln!(out, "{status}\n");
+        }
+    }
+    out
+}
+
+fn post_url(post: &Post) -> String {
+    format!(
+        "{site_url}/post/{slug}/{id}",
+        site_url = &*crate::SITE_URL,
+        slug = post.slug,
+        id = post.id,
+    )
+}
+
+fn author_url(author: &Author) -> String {
+    format!(
+        "{site_url}/author/{slug}",
+        site_url = &*crate::SITE_URL,
+        slug = author.slug,
+    )
+}
+
+fn author_name(author: &Author) -> String {
+    let name = [
+        author.first_name.as_deref(),
+        author.middle_name.as_deref(),
+        author.last_name.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .filter(|part| !part.is_empty())
+    .collect::<Vec<&str>>()
+    .join(" ");
+
+    if name.is_empty() {
+        author.slug.clone()
+    } else {
+        name
+    }
+}
+
+fn rfc3339(milliseconds: u64) -> String {
+    chrono::DateTime::from_timestamp(milliseconds as i64 / 1000, 0)
+        .unwrap_or_default()
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+struct FrontMatter {
+    lines: Vec<String>,
+}
+
+impl FrontMatter {
+    fn new() -> Self {
+        Self { lines: Vec::new() }
+    }
+
+    fn text(&mut self, key: &str, value: &str) {
+        self.lines.push(format!("{key}: {}", quoted(value)));
+    }
+
+    fn number(&mut self, key: &str, value: u64) {
+        self.lines.push(format!("{key}: {value}"));
+    }
+
+    fn list<'a>(&mut self, key: &str, values: impl Iterator<Item = &'a str>) {
+        let values = values.map(quoted).collect::<Vec<String>>().join(", ");
+        self.lines.push(format!("{key}: [{values}]"));
+    }
+
+    fn write_to(self, out: &mut String) {
+        let _ = writeln!(out, "---");
+        for line in self.lines {
+            let _ = writeln!(out, "{line}");
+        }
+        let _ = writeln!(out, "---\n");
+    }
+}
+
+fn quoted(value: &str) -> String {
+    let escaped = value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace(['\n', '\r'], " ");
+    format!("\"{escaped}\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_site_url() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| unsafe { std::env::set_var("SITE_URL", "https://example.com") });
+    }
+
+    fn author() -> Author {
+        Author {
+            id: 1,
+            slug: "jane_doe".to_string(),
+            first_name: Some("Jane".to_string()),
+            middle_name: None,
+            last_name: Some("Doe".to_string()),
+            mobile: None,
+            email: None,
+            registered_at: 1_700_000_000_000,
+            status: Some("writes things".to_string()),
+            image_url: None,
+            processed_image_urls: Default::default(),
+            editor: 0,
+            blocked: 0,
+            notification_subscribed: None,
+            override_social_data: 0,
+        }
+    }
+
+    fn post() -> Post {
+        Post {
+            id: 7,
+            title: "A \"quoted\" title".to_string(),
+            slug: "a-quoted-title".to_string(),
+            summary: "Summary of the post.".to_string(),
+            publish_type: PublishType::Published,
+            recommended: false,
+            created_at: 1_700_000_000_000,
+            content: Some("<p>Hello <b>world</b></p>".to_string()),
+            author: author(),
+            tags: vec![Tag {
+                id: 3,
+                title: "rust".to_string(),
+                slug: "rust".to_string(),
+            }],
+            image_url: None,
+            processed_image_urls: Default::default(),
+            noindex: false,
+        }
+    }
+
+    #[test]
+    fn post_markdown_has_front_matter_and_content() {
+        init_site_url();
+        let markdown = post_markdown(&post());
+
+        assert!(markdown.starts_with("---\n"));
+        assert!(markdown.contains("type: \"post\"\n"));
+        assert!(markdown.contains("title: \"A \\\"quoted\\\" title\"\n"));
+        assert!(markdown.contains("url: \"https://example.com/post/a-quoted-title/7\"\n"));
+        assert!(markdown.contains("author: \"Jane Doe\"\n"));
+        assert!(markdown.contains("published: \"2023-11-14T22:13:20Z\"\n"));
+        assert!(markdown.contains("tags: [\"rust\"]\n"));
+        assert!(markdown.contains("# A \"quoted\" title"));
+        assert!(markdown.contains("> Summary of the post."));
+        assert!(markdown.contains("Hello **world**"));
+    }
+
+    #[test]
+    fn posts_markdown_lists_every_post() {
+        init_site_url();
+        let container = PostsContainer {
+            posts: vec![post()],
+            base: TotalOffsetLimitContainer {
+                total: 1,
+                offset: 0,
+                limit: 10,
+            },
+        };
+        let markdown = posts_markdown(&container);
+
+        assert!(markdown.contains("type: \"posts\"\n"));
+        assert!(markdown.contains("total: 1\n"));
+        assert!(
+            markdown.contains("## [A \"quoted\" title](https://example.com/post/a-quoted-title/7)")
+        );
+        assert!(markdown.contains("[Jane Doe](https://example.com/author/jane_doe)"));
+    }
+
+    #[test]
+    fn author_name_falls_back_to_slug() {
+        let mut author = author();
+        author.first_name = None;
+        author.last_name = None;
+        assert_eq!(author_name(&author), "jane_doe");
+    }
+}

--- a/blog-server-api/src/endpoints/mod.rs
+++ b/blog-server-api/src/endpoints/mod.rs
@@ -1,3 +1,4 @@
+pub mod api_catalog_handler;
 pub mod author;
 pub mod author_block;
 pub mod author_me;
@@ -14,6 +15,9 @@ pub mod create_post;
 pub mod delete_comment;
 pub mod delete_post;
 pub mod login;
+#[cfg(feature = "ssr")]
+mod markdown_handler;
+pub mod openapi_handler;
 pub mod post;
 pub mod post_recommendation;
 pub mod post_update_recommended;
@@ -30,6 +34,9 @@ pub mod update_post;
 pub mod update_secondary_author;
 #[cfg(feature = "yandex")]
 pub mod yandex_login;
+
+pub use api_catalog_handler::api_catalog_handler;
+pub use openapi_handler::openapi_handler;
 
 #[cfg(feature = "ssr")]
 pub use client_handler::*;

--- a/blog-server-api/src/endpoints/openapi.json
+++ b/blog-server-api/src/endpoints/openapi.json
@@ -1,0 +1,2090 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Blog API",
+    "version": "1.0.0",
+    "summary": "Posts, authors and comments of the blog.",
+    "description": "Every response is wrapped in a single-key envelope: `success` with `identifier`, `description` and `data`, or `failure` with `identifier` and `reason`. Successful responses always answer `200 OK`; the `identifier` tells reads (`FOUND`), creations (`CREATED`) and other actions (`OK`) apart. Authenticated endpoints take a raw JWT in the `Token` header, obtained from one of the login endpoints.",
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "/api"
+    }
+  ],
+  "tags": [
+    {
+      "name": "posts",
+      "description": "Reading and editing posts."
+    },
+    {
+      "name": "authors",
+      "description": "Reading and editing author profiles."
+    },
+    {
+      "name": "comments",
+      "description": "Reading and writing post comments."
+    },
+    {
+      "name": "auth",
+      "description": "Obtaining an authentication token."
+    },
+    {
+      "name": "chat",
+      "description": "Question answering over the blog content."
+    }
+  ],
+  "paths": {
+    "/posts": {
+      "get": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "List published posts",
+        "operationId": "listPosts",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SearchQuery"
+          },
+          {
+            "$ref": "#/components/parameters/AuthorId"
+          },
+          {
+            "$ref": "#/components/parameters/TagId"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Posts"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/posts/unpublished": {
+      "get": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "List unpublished posts visible to the caller",
+        "operationId": "listUnpublishedPosts",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SearchQuery"
+          },
+          {
+            "$ref": "#/components/parameters/AuthorId"
+          },
+          {
+            "$ref": "#/components/parameters/TagId"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Posts"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/posts/hidden": {
+      "get": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "List hidden posts visible to the caller",
+        "operationId": "listHiddenPosts",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SearchQuery"
+          },
+          {
+            "$ref": "#/components/parameters/AuthorId"
+          },
+          {
+            "$ref": "#/components/parameters/TagId"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Posts"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/post": {
+      "post": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "Create a post",
+        "operationId": "createPost",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommonPost"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Post"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/post/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/PostId"
+        }
+      ],
+      "get": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "Read one post",
+        "description": "Readable anonymously. A valid `Token` additionally exposes posts that are not published, when the caller is allowed to see them.",
+        "operationId": "getPost",
+        "security": [
+          {},
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Post"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "Update a post",
+        "operationId": "updatePost",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommonPost"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Post"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "Delete a post",
+        "operationId": "deletePost",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/post/{id}/recommendation": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/PostId"
+        }
+      ],
+      "get": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "Read the post recommended after this one",
+        "operationId": "getPostRecommendation",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Post"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/post/{id}/recommended/true": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/PostId"
+        }
+      ],
+      "patch": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "Mark a post as recommended",
+        "operationId": "markPostRecommended",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/post/{id}/recommended/false": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/PostId"
+        }
+      ],
+      "patch": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "Clear the recommended flag of a post",
+        "operationId": "unmarkPostRecommended",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/tag/{id}": {
+      "get": {
+        "tags": [
+          "posts"
+        ],
+        "summary": "Read one tag",
+        "operationId": "getTag",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Tag id."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tag found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/authors": {
+      "get": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "List authors",
+        "operationId": "listAuthors",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Offset"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Authors"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/authors/search/{query}": {
+      "get": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Search authors",
+        "operationId": "searchAuthors",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Free text matched against author names and slugs."
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Authors"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/author/slug/{slug}": {
+      "get": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Read one author by slug",
+        "operationId": "getAuthorBySlug",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Author slug as it appears in profile URLs."
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Author"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/author/me": {
+      "get": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Read the signed-in author",
+        "operationId": "getOwnAuthor",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Author"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/author/minimal": {
+      "patch": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Update slug, name and image of the signed-in author",
+        "operationId": "updateOwnMinimalAuthor",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommonMinimalAuthor"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/author/secondary": {
+      "patch": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Update contacts and status of the signed-in author",
+        "operationId": "updateOwnSecondaryAuthor",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommonSecondaryAuthor"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/author/reset_override_social_data": {
+      "patch": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Let social login data overwrite the profile again",
+        "operationId": "resetOwnSocialDataOverride",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/author/id/{id}/subscribe": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AuthorPathId"
+        }
+      ],
+      "patch": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Subscribe to an author's new posts",
+        "operationId": "subscribeToAuthor",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/author/id/{id}/unsubscribe": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AuthorPathId"
+        }
+      ],
+      "patch": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Unsubscribe from an author's new posts",
+        "operationId": "unsubscribeFromAuthor",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/author/id/{id}/block": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AuthorPathId"
+        }
+      ],
+      "get": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Block an author",
+        "description": "Requires editor rights.",
+        "operationId": "blockAuthor",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/author/id/{id}/unblock": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/AuthorPathId"
+        }
+      ],
+      "get": {
+        "tags": [
+          "authors"
+        ],
+        "summary": "Unblock an author",
+        "description": "Requires editor rights.",
+        "operationId": "unblockAuthor",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/comments/{post_id}": {
+      "get": {
+        "tags": [
+          "comments"
+        ],
+        "summary": "List the comments of a post",
+        "operationId": "listComments",
+        "parameters": [
+          {
+            "name": "post_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Post id."
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Comments returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentsSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/comment": {
+      "post": {
+        "tags": [
+          "comments"
+        ],
+        "summary": "Write a comment",
+        "operationId": "createComment",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommonComment"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/comment/{id}": {
+      "delete": {
+        "tags": [
+          "comments"
+        ],
+        "summary": "Delete a comment",
+        "operationId": "deleteComment",
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comment id."
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "403": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "404": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Exchange slug and password for a token",
+        "operationId": "login",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginQuestion"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Login"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/ylogin": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Exchange a Yandex OAuth token for a token",
+        "operationId": "loginWithYandex",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginYandexQuestion"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Login"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/tlogin": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Exchange a Telegram login payload for a token",
+        "operationId": "loginWithTelegram",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginTelegramQuestion"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Login"
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "401": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    },
+    "/chatgpt": {
+      "post": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Ask a question about the blog content",
+        "operationId": "askChat",
+        "parameters": [
+          {
+            "name": "Chat-Session-Id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Caller-generated UUID that groups the messages of one conversation."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatQuestion"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Answer produced.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "429": {
+            "$ref": "#/components/responses/Failure"
+          },
+          "500": {
+            "$ref": "#/components/responses/Failure"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "TokenAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Token",
+        "description": "The raw JWT returned by a login endpoint, with no scheme prefix."
+      }
+    },
+    "parameters": {
+      "Offset": {
+        "name": "offset",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "minimum": 0
+        },
+        "description": "Records to skip. Defaults to 0."
+      },
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "minimum": 1
+        },
+        "description": "Maximum records to return."
+      },
+      "SearchQuery": {
+        "name": "search_query",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Free text matched against post titles and content."
+      },
+      "AuthorId": {
+        "name": "author_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "description": "Keep only the posts of this author."
+      },
+      "TagId": {
+        "name": "tag_id",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "description": "Keep only the posts carrying this tag."
+      },
+      "PostId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Post id."
+      },
+      "AuthorPathId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Author id."
+      }
+    },
+    "responses": {
+      "Post": {
+        "description": "One post.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PostSuccess"
+            }
+          }
+        }
+      },
+      "Posts": {
+        "description": "A page of posts.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PostsSuccess"
+            }
+          }
+        }
+      },
+      "Author": {
+        "description": "One author.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AuthorSuccess"
+            }
+          }
+        }
+      },
+      "Authors": {
+        "description": "A page of authors.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AuthorsSuccess"
+            }
+          }
+        }
+      },
+      "Login": {
+        "description": "An authentication token.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LoginSuccess"
+            }
+          }
+        }
+      },
+      "Empty": {
+        "description": "The action was carried out.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/EmptySuccess"
+            }
+          }
+        }
+      },
+      "Failure": {
+        "description": "The request was rejected. `identifier` names the reason in SCREAMING_SNAKE.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Failure"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "SuccessBody": {
+        "type": "object",
+        "required": [
+          "identifier",
+          "description",
+          "data"
+        ],
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "description": "`FOUND` for reads, `CREATED` for creation, `OK` for every other action."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "Failure": {
+        "type": "object",
+        "required": [
+          "failure"
+        ],
+        "properties": {
+          "failure": {
+            "type": "object",
+            "required": [
+              "identifier",
+              "reason"
+            ],
+            "properties": {
+              "identifier": {
+                "type": "string"
+              },
+              "reason": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "PostSuccess": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessBody"
+              }
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/PostContainer"
+              }
+            }
+          }
+        }
+      },
+      "PostsSuccess": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessBody"
+              }
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/PostsContainer"
+              }
+            }
+          }
+        }
+      },
+      "AuthorSuccess": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessBody"
+              }
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/AuthorContainer"
+              }
+            }
+          }
+        }
+      },
+      "AuthorsSuccess": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessBody"
+              }
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/AuthorsContainer"
+              }
+            }
+          }
+        }
+      },
+      "TagSuccess": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessBody"
+              }
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/TagContainer"
+              }
+            }
+          }
+        }
+      },
+      "CommentsSuccess": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessBody"
+              }
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/CommentsContainer"
+              }
+            }
+          }
+        }
+      },
+      "LoginSuccess": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessBody"
+              }
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/LoginAnswer"
+              }
+            }
+          }
+        }
+      },
+      "ChatSuccess": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessBody"
+              }
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/ChatAnswer"
+              }
+            }
+          }
+        }
+      },
+      "EmptySuccess": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessBody"
+              }
+            ],
+            "properties": {
+              "data": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      },
+      "Pagination": {
+        "type": "object",
+        "required": [
+          "total",
+          "offset",
+          "limit"
+        ],
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "PostContainer": {
+        "type": "object",
+        "required": [
+          "post"
+        ],
+        "properties": {
+          "post": {
+            "$ref": "#/components/schemas/Post"
+          }
+        }
+      },
+      "PostsContainer": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pagination"
+          }
+        ],
+        "required": [
+          "posts"
+        ],
+        "properties": {
+          "posts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Post"
+            }
+          }
+        }
+      },
+      "AuthorContainer": {
+        "type": "object",
+        "required": [
+          "author"
+        ],
+        "properties": {
+          "author": {
+            "$ref": "#/components/schemas/Author"
+          }
+        }
+      },
+      "AuthorsContainer": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pagination"
+          }
+        ],
+        "required": [
+          "authors"
+        ],
+        "properties": {
+          "authors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Author"
+            }
+          }
+        }
+      },
+      "TagContainer": {
+        "type": "object",
+        "required": [
+          "tag"
+        ],
+        "properties": {
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        }
+      },
+      "CommentsContainer": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pagination"
+          }
+        ],
+        "required": [
+          "comments"
+        ],
+        "properties": {
+          "comments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Comment"
+            }
+          }
+        }
+      },
+      "PublishType": {
+        "type": "integer",
+        "enum": [
+          0,
+          1,
+          2
+        ],
+        "description": "0 unpublished, 1 published, 2 hidden."
+      },
+      "Flag": {
+        "type": "integer",
+        "enum": [
+          0,
+          1
+        ],
+        "description": "0 false, 1 true."
+      },
+      "ProcessedImageUrls": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "Signed image URLs by size key. Empty when the images processor is not configured."
+      },
+      "Post": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "slug",
+          "summary",
+          "publishType",
+          "recommended",
+          "createdAt",
+          "author",
+          "tags",
+          "processedImageUrls",
+          "noindex"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string",
+            "description": "Together with `id` this forms the page URL `/post/{slug}/{id}`."
+          },
+          "summary": {
+            "type": "string"
+          },
+          "publishType": {
+            "$ref": "#/components/schemas/PublishType"
+          },
+          "recommended": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Milliseconds since the Unix epoch."
+          },
+          "content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Sanitized HTML. Absent in list responses."
+          },
+          "author": {
+            "$ref": "#/components/schemas/Author"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "imageUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "processedImageUrls": {
+            "$ref": "#/components/schemas/ProcessedImageUrls"
+          },
+          "noindex": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Author": {
+        "type": "object",
+        "required": [
+          "id",
+          "slug",
+          "registeredAt",
+          "processedImageUrls",
+          "editor",
+          "blocked",
+          "overrideSocialData"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "slug": {
+            "type": "string",
+            "description": "Forms the profile URL `/author/{slug}`."
+          },
+          "firstName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "middleName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lastName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mobile": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "registeredAt": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Milliseconds since the Unix epoch."
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "imageUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "processedImageUrls": {
+            "$ref": "#/components/schemas/ProcessedImageUrls"
+          },
+          "editor": {
+            "$ref": "#/components/schemas/Flag"
+          },
+          "blocked": {
+            "$ref": "#/components/schemas/Flag"
+          },
+          "notificationSubscribed": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Flag"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Present only when the request was authenticated."
+          },
+          "overrideSocialData": {
+            "$ref": "#/components/schemas/Flag"
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "slug"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          }
+        }
+      },
+      "Comment": {
+        "type": "object",
+        "required": [
+          "id",
+          "postId",
+          "createdAt",
+          "author"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "postId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "createdAt": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Milliseconds since the Unix epoch."
+          },
+          "content": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "author": {
+            "$ref": "#/components/schemas/Author"
+          }
+        }
+      },
+      "CommonPost": {
+        "type": "object",
+        "required": [
+          "title",
+          "publishType",
+          "summary",
+          "tags"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 10,
+            "maxLength": 75
+          },
+          "publishType": {
+            "$ref": "#/components/schemas/PublishType"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 50,
+            "maxLength": 255
+          },
+          "content": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 50,
+            "description": "HTML. Sanitized on the server before it is stored."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 15
+            },
+            "description": "Alphanumeric tag titles."
+          },
+          "imageUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "maxLength": 150
+          }
+        }
+      },
+      "CommonComment": {
+        "type": "object",
+        "required": [
+          "postId",
+          "content"
+        ],
+        "properties": {
+          "postId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      },
+      "CommonMinimalAuthor": {
+        "type": "object",
+        "required": [
+          "slug"
+        ],
+        "properties": {
+          "slug": {
+            "type": "string",
+            "minLength": 5,
+            "maxLength": 30,
+            "description": "Alphanumeric characters and underscores."
+          },
+          "firstName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 2,
+            "maxLength": 50
+          },
+          "lastName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 2,
+            "maxLength": 50
+          },
+          "imageUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "maxLength": 255
+          }
+        }
+      },
+      "CommonSecondaryAuthor": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "email",
+            "maxLength": 50
+          },
+          "mobile": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 50
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 100
+          }
+        }
+      },
+      "LoginQuestion": {
+        "type": "object",
+        "required": [
+          "slug",
+          "password"
+        ],
+        "properties": {
+          "slug": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        }
+      },
+      "LoginYandexQuestion": {
+        "type": "object",
+        "required": [
+          "accessToken",
+          "tokenType",
+          "expiresIn"
+        ],
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          },
+          "tokenType": {
+            "type": "string"
+          },
+          "expiresIn": {
+            "type": "string"
+          }
+        },
+        "description": "The snake_case spellings `access_token`, `token_type` and `expires_in` are accepted as well."
+      },
+      "LoginTelegramQuestion": {
+        "type": "object",
+        "required": [
+          "id",
+          "auth_date",
+          "hash"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "first_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "username": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "photo_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "auth_date": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "hash": {
+            "type": "string",
+            "description": "Telegram's signature over the other fields, checked with the bot token."
+          }
+        }
+      },
+      "LoginAnswer": {
+        "type": "object",
+        "required": [
+          "token"
+        ],
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Send this back in the `Token` header."
+          }
+        }
+      },
+      "ChatQuestion": {
+        "type": "object",
+        "required": [
+          "question"
+        ],
+        "properties": {
+          "question": {
+            "type": "string"
+          }
+        }
+      },
+      "ChatAnswer": {
+        "type": "object",
+        "required": [
+          "answer"
+        ],
+        "properties": {
+          "answer": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/blog-server-api/src/endpoints/openapi_handler.rs
+++ b/blog-server-api/src/endpoints/openapi_handler.rs
@@ -1,0 +1,120 @@
+use screw_core::request::*;
+use screw_core::response::*;
+use screw_core::routing::*;
+
+pub const OPENAPI_PATH: &str = "/openapi.json";
+pub const OPENAPI_MEDIA_TYPE: &str = "application/vnd.oai.openapi+json;version=3.1";
+
+static OPENAPI: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+    let mut document: serde_json::Value = serde_json::from_str(include_str!("openapi.json"))
+        .unwrap_or_else(|e| panic!("failed to parse openapi.json: {e}"));
+
+    document["servers"] = serde_json::json!([{
+        "url": format!("{site_url}/api", site_url = &*crate::SITE_URL),
+    }]);
+
+    if let Some(paths) = document["paths"].as_object_mut() {
+        for (path, enabled) in [
+            ("/chatgpt", cfg!(feature = "chatgpt")),
+            ("/ylogin", cfg!(feature = "yandex")),
+            ("/tlogin", cfg!(feature = "telegram")),
+        ] {
+            if !enabled {
+                paths.remove(path);
+            }
+        }
+    }
+
+    serde_json::to_string(&document).expect("failed to serialize openapi document")
+});
+
+pub async fn openapi_handler<Extensions>(
+    _: router::RoutedRequest<Request<Extensions>>,
+) -> Response {
+    Response {
+        http: hyper::Response::builder()
+            .header("Content-Type", OPENAPI_MEDIA_TYPE)
+            .header("Cache-Control", "public, max-age=3600")
+            .body(screw_core::body::full(OPENAPI.as_str()))
+            .unwrap(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn document() -> serde_json::Value {
+        unsafe { std::env::set_var("SITE_URL", "https://example.com") };
+        serde_json::from_str(&OPENAPI).unwrap()
+    }
+
+    #[test]
+    fn servers_point_at_the_running_site() {
+        assert_eq!(document()["servers"][0]["url"], "https://example.com/api");
+    }
+
+    #[test]
+    fn feature_gated_paths_follow_the_build() {
+        let document = document();
+        let paths = document["paths"].as_object().unwrap();
+        assert_eq!(paths.contains_key("/chatgpt"), cfg!(feature = "chatgpt"));
+        assert_eq!(paths.contains_key("/ylogin"), cfg!(feature = "yandex"));
+        assert_eq!(paths.contains_key("/tlogin"), cfg!(feature = "telegram"));
+    }
+
+    #[test]
+    fn always_available_paths_are_described() {
+        let document = document();
+        let paths = document["paths"].as_object().unwrap();
+        for path in [
+            "/posts",
+            "/post",
+            "/post/{id}",
+            "/authors",
+            "/author/slug/{slug}",
+            "/author/me",
+            "/comments/{post_id}",
+            "/comment",
+            "/login",
+        ] {
+            assert!(paths.contains_key(path), "{path} is missing");
+        }
+    }
+
+    #[test]
+    fn every_reference_resolves() {
+        let document = document();
+        let mut references = Vec::new();
+        collect_references(&document, &mut references);
+        assert!(!references.is_empty());
+
+        for reference in references {
+            let mut node = &document;
+            for segment in reference.trim_start_matches("#/").split('/') {
+                node = node
+                    .get(segment)
+                    .unwrap_or_else(|| panic!("{reference} does not resolve"));
+            }
+        }
+    }
+
+    fn collect_references(node: &serde_json::Value, out: &mut Vec<String>) {
+        match node {
+            serde_json::Value::Object(map) => {
+                for (key, value) in map {
+                    match value.as_str() {
+                        Some(reference) if key == "$ref" => out.push(reference.to_string()),
+                        _ => collect_references(value, out),
+                    }
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    collect_references(item, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/blog-server-api/src/endpoints/robots_handler.rs
+++ b/blog-server-api/src/endpoints/robots_handler.rs
@@ -4,9 +4,7 @@ use screw_core::routing::*;
 
 // Served via nginx exclusion -> proxied to the server so the absolute
 // `Sitemap:` URL can be built from the runtime SITE_URL.
-pub async fn robots_handler<Extensions>(
-    _: router::RoutedRequest<Request<Extensions>>,
-) -> Response {
+pub async fn robots_handler<Extensions>(_: router::RoutedRequest<Request<Extensions>>) -> Response {
     let body = format!(
         "User-agent: *\n\
          Allow: /\n\

--- a/blog-server-api/src/endpoints/sitemap_handler.rs
+++ b/blog-server-api/src/endpoints/sitemap_handler.rs
@@ -52,27 +52,29 @@ pub async fn sitemap_handler<Extensions: Resolve<Arc<dyn PostService>>>(
             .unwrap(),
     ];
 
-    urls.extend(posts
-        .into_iter()
-        .map(|post| {
-            Url::builder(format!(
-                "{site_url}/post/{slug}/{id}",
-                site_url = &*crate::SITE_URL,
-                slug = post.base.slug,
-                id = post.id,
-            ))
-            .last_modified(DateTime::from_naive_utc_and_offset(
-                DateTime::from_timestamp(post.base.created_at as i64 / 1000, 0)
-                    .unwrap()
-                    .naive_utc(),
-                FixedOffset::east_opt(0).unwrap(),
-            ))
-            .change_frequency(ChangeFrequency::Weekly)
-            .priority(1.0)
-            .build()
-            .unwrap()
-        })
-        .collect::<Vec<Url>>());
+    urls.extend(
+        posts
+            .into_iter()
+            .map(|post| {
+                Url::builder(format!(
+                    "{site_url}/post/{slug}/{id}",
+                    site_url = &*crate::SITE_URL,
+                    slug = post.base.slug,
+                    id = post.id,
+                ))
+                .last_modified(DateTime::from_naive_utc_and_offset(
+                    DateTime::from_timestamp(post.base.created_at as i64 / 1000, 0)
+                        .unwrap()
+                        .naive_utc(),
+                    FixedOffset::east_opt(0).unwrap(),
+                ))
+                .change_frequency(ChangeFrequency::Weekly)
+                .priority(1.0)
+                .build()
+                .unwrap()
+            })
+            .collect::<Vec<Url>>(),
+    );
     urls.truncate(RECORDS_LIMIT);
 
     let url_set: UrlSet = UrlSet::new(urls).unwrap();

--- a/blog-server-api/src/router.rs
+++ b/blog-server-api/src/router.rs
@@ -295,6 +295,16 @@ pub fn make_router<Extensions: ExtensionsProviderType>()
                 .and_path("/robots.txt")
                 .and_handler(robots_handler),
         )
+        .route(
+            route::first::Route::with_method(&hyper::Method::GET)
+                .and_path(api_catalog_handler::API_CATALOG_PATH)
+                .and_handler(api_catalog_handler),
+        )
+        .route(
+            route::first::Route::with_method(&hyper::Method::GET)
+                .and_path(openapi_handler::OPENAPI_PATH)
+                .and_handler(openapi_handler),
+        )
     })
 }
 
@@ -337,5 +347,68 @@ mod tests {
     #[test]
     fn router_builds_without_route_conflicts() {
         let _ = make_router::<StubExtensions>();
+    }
+
+    async fn serve() -> std::net::SocketAddr {
+        unsafe { std::env::set_var("SITE_URL", "https://example.com") };
+
+        let server_service = Arc::new(screw_core::server::ServerService::with_responder_factory(
+            screw_core::responder_factory::ResponderFactory::with_router(make_router())
+                .and_extensions(StubExtensions),
+        ));
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            loop {
+                let (stream, remote_addr) = listener.accept().await.unwrap();
+                let session_service = server_service.make_session_service(remote_addr);
+                tokio::spawn(async move {
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(hyper_util::rt::TokioIo::new(stream), session_service)
+                        .await;
+                });
+            }
+        });
+
+        addr
+    }
+
+    async fn get(addr: std::net::SocketAddr, path: &str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(
+                format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        String::from_utf8_lossy(&response).into_owned()
+    }
+
+    #[tokio::test]
+    async fn api_catalog_is_served_from_well_known() {
+        let addr = serve().await;
+        let response = get(addr, api_catalog_handler::API_CATALOG_PATH).await;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+        assert!(response.contains("content-type: application/linkset+json"));
+        assert!(response.contains("\"anchor\":\"https://example.com/api\""));
+    }
+
+    #[tokio::test]
+    async fn openapi_document_is_served() {
+        let addr = serve().await;
+        let response = get(addr, openapi_handler::OPENAPI_PATH).await;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+        assert!(response.contains("content-type: application/vnd.oai.openapi+json;version=3.1"));
+        assert!(response.contains("\"openapi\":\"3.1.0\""));
     }
 }

--- a/blog-server-api/src/utils/accept.rs
+++ b/blog-server-api/src/utils/accept.rs
@@ -1,0 +1,105 @@
+use hyper::header::{ACCEPT, HeaderMap};
+
+pub const MARKDOWN_MEDIA_TYPE: &str = "text/markdown";
+pub const HTML_MEDIA_TYPE: &str = "text/html";
+
+pub fn prefers_markdown(headers: &HeaderMap) -> bool {
+    let Some(accept) = headers.get(ACCEPT).and_then(|v| v.to_str().ok()) else {
+        return false;
+    };
+    quality(accept, MARKDOWN_MEDIA_TYPE) > quality(accept, HTML_MEDIA_TYPE)
+}
+
+fn quality(accept: &str, media_type: &str) -> f32 {
+    let (media_kind, _) = media_type.split_once('/').unwrap_or((media_type, ""));
+
+    let mut best = None;
+    let mut best_precision = 0;
+
+    for entry in accept.split(',') {
+        let mut parts = entry.split(';').map(str::trim);
+        let Some(candidate) = parts.next() else {
+            continue;
+        };
+
+        let precision = if candidate.eq_ignore_ascii_case(media_type) {
+            3
+        } else if candidate.eq_ignore_ascii_case(&format!("{media_kind}/*")) {
+            2
+        } else if candidate == "*/*" {
+            1
+        } else {
+            continue;
+        };
+
+        if precision < best_precision {
+            continue;
+        }
+
+        let q = parts
+            .find_map(|p| p.strip_prefix("q="))
+            .and_then(|q| q.parse::<f32>().ok())
+            .unwrap_or(1.0);
+
+        if precision > best_precision || q > best.unwrap_or(0.0) {
+            best_precision = precision;
+            best = Some(q);
+        }
+    }
+
+    best.unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(accept: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, accept.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn browser_accept_keeps_html() {
+        assert!(!prefers_markdown(&headers(
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+        )));
+    }
+
+    #[test]
+    fn explicit_markdown_wins() {
+        assert!(prefers_markdown(&headers("text/markdown")));
+        assert!(prefers_markdown(&headers("text/markdown, text/html;q=0.9")));
+        assert!(prefers_markdown(&headers(
+            "text/html;q=0.5, text/markdown;q=1.0"
+        )));
+    }
+
+    #[test]
+    fn html_wins_when_ranked_higher() {
+        assert!(!prefers_markdown(&headers(
+            "text/markdown;q=0.5, text/html;q=0.9"
+        )));
+    }
+
+    #[test]
+    fn wildcards_do_not_prefer_markdown() {
+        assert!(!prefers_markdown(&headers("*/*")));
+        assert!(!prefers_markdown(&headers("text/*")));
+    }
+
+    #[test]
+    fn missing_or_unrelated_accept_keeps_html() {
+        assert!(!prefers_markdown(&HeaderMap::new()));
+        assert!(!prefers_markdown(&headers("application/json")));
+    }
+
+    #[test]
+    fn wildcard_covers_html_when_markdown_is_downranked() {
+        assert!(!prefers_markdown(&headers(
+            "text/markdown;q=0.6, */*;q=0.9"
+        )));
+        assert!(prefers_markdown(&headers("text/markdown;q=0.9, */*;q=0.6")));
+    }
+}

--- a/blog-server-api/src/utils/mod.rs
+++ b/blog-server-api/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod accept;
 pub mod auth;
 pub mod auth_middleware;
 pub mod jwt;

--- a/blog-server-services/src/utils/html.rs
+++ b/blog-server-services/src/utils/html.rs
@@ -30,6 +30,152 @@ pub fn to_plain(src: &str) -> String {
     html2text::from_read(src.as_bytes(), usize::MAX)
 }
 
+pub fn to_markdown(src: &str) -> String {
+    let normalized = normalize_inline_tags(src);
+    html2text::from_read_with_decorator(
+        normalized.as_bytes(),
+        MARKDOWN_WIDTH,
+        MarkdownDecorator::new(),
+    )
+    .replace(STRIKEOUT_OVERLAY, "")
+    .trim()
+    .to_string()
+}
+
+const MARKDOWN_WIDTH: usize = 120;
+const STRIKEOUT_OVERLAY: char = '\u{336}';
+
+const INLINE_TAG_ALIASES: &[(&str, &str)] =
+    &[("b", "strong"), ("i", "em"), ("del", "s"), ("strike", "s")];
+
+fn normalize_inline_tags(src: &str) -> String {
+    INLINE_TAG_ALIASES
+        .iter()
+        .fold(src.to_string(), |acc, (from, to)| {
+            rename_tag(&acc, from, to)
+        })
+}
+
+fn rename_tag(src: &str, from: &str, to: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut rest = src;
+
+    while let Some(index) = rest.find('<') {
+        out.push_str(&rest[..index]);
+        rest = &rest[index..];
+
+        let name_start = if rest.starts_with("</") { 2 } else { 1 };
+        let after_bracket = &rest[name_start..];
+        let name_len = after_bracket
+            .find(|c: char| !c.is_ascii_alphanumeric())
+            .unwrap_or(after_bracket.len());
+
+        if after_bracket[..name_len].eq_ignore_ascii_case(from) {
+            out.push_str(&rest[..name_start]);
+            out.push_str(to);
+            rest = &after_bracket[name_len..];
+        } else {
+            out.push_str(&rest[..name_start]);
+            rest = after_bracket;
+        }
+    }
+
+    out.push_str(rest);
+    out
+}
+
+#[derive(Clone, Debug, Default)]
+struct MarkdownDecorator {
+    link_urls: Vec<String>,
+}
+
+impl MarkdownDecorator {
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl html2text::render::text_renderer::TextDecorator for MarkdownDecorator {
+    type Annotation = ();
+
+    fn decorate_link_start(&mut self, url: &str) -> (String, Self::Annotation) {
+        self.link_urls.push(url.to_string());
+        ("[".to_string(), ())
+    }
+
+    fn decorate_link_end(&mut self) -> String {
+        let url = self.link_urls.pop().unwrap_or_default();
+        format!("]({url})")
+    }
+
+    fn decorate_em_start(&mut self) -> (String, Self::Annotation) {
+        ("*".to_string(), ())
+    }
+
+    fn decorate_em_end(&mut self) -> String {
+        "*".to_string()
+    }
+
+    fn decorate_strong_start(&mut self) -> (String, Self::Annotation) {
+        ("**".to_string(), ())
+    }
+
+    fn decorate_strong_end(&mut self) -> String {
+        "**".to_string()
+    }
+
+    fn decorate_strikeout_start(&mut self) -> (String, Self::Annotation) {
+        ("~~".to_string(), ())
+    }
+
+    fn decorate_strikeout_end(&mut self) -> String {
+        "~~".to_string()
+    }
+
+    fn decorate_code_start(&mut self) -> (String, Self::Annotation) {
+        ("`".to_string(), ())
+    }
+
+    fn decorate_code_end(&mut self) -> String {
+        "`".to_string()
+    }
+
+    fn decorate_preformat_first(&mut self) -> Self::Annotation {}
+
+    fn decorate_preformat_cont(&mut self) -> Self::Annotation {}
+
+    fn decorate_image(&mut self, src: &str, title: &str) -> (String, Self::Annotation) {
+        (format!("![{title}]({src})"), ())
+    }
+
+    fn header_prefix(&mut self, level: usize) -> String {
+        "#".repeat(level) + " "
+    }
+
+    fn quote_prefix(&mut self) -> String {
+        "> ".to_string()
+    }
+
+    fn unordered_item_prefix(&mut self) -> String {
+        "- ".to_string()
+    }
+
+    fn ordered_item_prefix(&mut self, i: i64) -> String {
+        format!("{i}. ")
+    }
+
+    fn make_subblock_decorator(&self) -> Self {
+        self.clone()
+    }
+
+    fn finalise(
+        &mut self,
+        _links: Vec<String>,
+    ) -> Vec<html2text::render::text_renderer::TaggedLine<Self::Annotation>> {
+        Vec::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,5 +196,46 @@ mod tests {
         assert!(plain.contains("Hello"));
         assert!(plain.contains("World"));
         assert!(!plain.contains("<"));
+    }
+
+    #[test]
+    fn to_markdown_keeps_inline_links() {
+        let markdown = to_markdown("<p>see <a href=\"https://example.com/a\">this</a></p>");
+        assert!(markdown.contains("[this](https://example.com/a)"));
+    }
+
+    #[test]
+    fn to_markdown_renders_headers_and_lists() {
+        let markdown = to_markdown("<h2>Title</h2><ul><li>one</li><li>two</li></ul>");
+        assert!(markdown.contains("## Title"));
+        assert!(markdown.contains("- one"));
+        assert!(markdown.contains("- two"));
+    }
+
+    #[test]
+    fn to_markdown_renders_emphasis_and_images() {
+        let markdown = to_markdown(
+            "<p><strong>bold</strong> <em>italic</em></p><img src=\"/i.png\" alt=\"x\">",
+        );
+        assert!(markdown.contains("**bold**"));
+        assert!(markdown.contains("*italic*"));
+        assert!(markdown.contains("![x](/i.png)"));
+    }
+
+    #[test]
+    fn to_markdown_understands_editor_inline_tags() {
+        let markdown = to_markdown(
+            "<p><b style=\"x\">bold</b> <i>italic</i> <del>gone</del> <strike>gone too</strike></p>",
+        );
+        assert!(markdown.contains("**bold**"));
+        assert!(markdown.contains("*italic*"));
+        assert!(markdown.contains("~~gone~~"));
+        assert!(markdown.contains("~~gone too~~"));
+    }
+
+    #[test]
+    fn rename_tag_leaves_similar_names_alone() {
+        let renamed = rename_tag("<b>x</b><body>y</body><br/>", "b", "strong");
+        assert_eq!(renamed, "<strong>x</strong><body>y</body><br/>");
     }
 }


### PR DESCRIPTION
…otiation

Serve Link headers on every SSR page pointing at /.well-known/api-catalog (rel=api-catalog) and /openapi.json (rel=service-desc), with Vary: Accept.

Add an RFC 9727 API catalog as application/linkset+json, anchored at the /api base, and an OpenAPI 3.1 document covering every route. The document takes its servers entry from SITE_URL at startup and drops the chatgpt, yandex and telegram paths when those features are off, so it always matches the running binary.

Serve markdown to callers that ask for it: Accept is compared by q-value, so browsers keep HTML while Accept: text/markdown returns the post, post list, author and author list pages as markdown with YAML front matter. Post content goes through a new html::to_markdown built on an html2text decorator, which also maps b/i/del/strike onto the tags html2text decorates and strips its combining-overlay strikeout glyphs.

Let nginx proxy /openapi.json instead of looking for it on disk, and gzip the new media types.